### PR TITLE
wraps keycloak register/login functionality

### DIFF
--- a/app/Console/Commands/keycloaktest.php
+++ b/app/Console/Commands/keycloaktest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Keycloak;
+
+use Illuminate\Console\Command;
+
+class keycloaktest extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:keycloak-test';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Command description';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $credentials = [
+            'email' => 'dr@who.com',
+            'first_name' => 'Dr',
+            'last_name' => 'Who',
+            'password' => 'tempP4ssword',
+            'is_researcher' => true,
+        ];
+
+        Keycloak::createUser($credentials);
+    }
+}

--- a/app/Http/Controllers/Api/V1/UserController.php
+++ b/app/Http/Controllers/Api/V1/UserController.php
@@ -176,10 +176,9 @@ class UserController extends Controller
             $user = User::create([
                 'name' => $input['name'],
                 'email' => $input['email'],
-                'email_verified_at' => isset($input['email_verified_at']) ? $input['email_verified_at'] : null,
                 'provider' => isset($input['provider']) ? $input['provider'] : '',
-                'provider_sub' => isset($input['provider_sub']) ? $input['provider_sub'] : '',
                 'registry_id' => isset($input['registry_id']) ? $input['registry_id'] : null,
+                'keycloak_id' => null,
             ]);
 
             return response()->json([

--- a/app/Keycloak/Keycloak.php
+++ b/app/Keycloak/Keycloak.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace App\Keycloak;
+
+use Http;
+use Exception;
+
+use App\Models\User;
+
+use Illuminate\Http\JsonResponse;
+
+class Keycloak {
+    const USERS_URL = '/users';
+
+    public function createUser(array $credentials): bool
+    {
+        try {
+            $payload = [
+                'username' => $credentials['email'],
+                'email' => $credentials['email'],
+                'emailVerified' => false,
+                'enabled' => true,
+                'firstName' => $credentials['first_name'],
+                'lastName' => $credentials['last_name'],
+                'credentials' => [
+                    [
+                        'value' => $credentials['password'],
+                        'temporary' => false,
+                        'type' => 'password',
+                    ],
+                ],
+                'requiredActions' => [
+                    'VERIFY_EMAIL',
+                    'CONFIGURE_TOTP',
+                ],
+            ];
+
+            isset($credentials['is_researcher']) ? $payload['groups'][] = '/Researchers' : null;
+            isset($credentials['is_issuer']) ? $payload['groups'][] = '/Issuers' : null;
+            isset($credentials['is_organisation']) ? $payload['groups'][] = '/Organisations' : null;
+
+            $response = Http::withHeaders([
+                'Authorization' => 'Bearer ' . $this->getServiceToken(),
+            ])->post(
+                $this->makeUrl(self::USERS_URL),
+                $payload
+            );
+
+            if ($response->status() === 201) {
+                $headers = $response->headers();
+                $parts = explode('/', $headers['Location'][0]);
+                $last = count($parts) -1;
+                $newUserId = $parts[$last];
+
+                $user = User::create([
+                    'name' => $credentials['first_name'] . ' ' . $credentials['last_name'],
+                    'email' => $credentials['email'],
+                    'provider' => 'keycloak',
+                    'provider_sub' => '',
+                    'keycloak_id' => $newUserId,
+                ]);
+
+                if (!$user)  return false; 
+
+                if (isset($credentials['is_researcher']) && $credentials['is_researcher'] === true) {
+                    $registry = Registry::create([
+                        'user_id' => $user->id,
+                    ]);
+                }
+
+                return true;
+            }
+
+            return false;
+        } catch (Exception $e) {
+            throw new Exception($e->getMessage());
+        }
+    }
+
+    public function login(string $username, string $password): array
+    {
+        try {
+            $authUrl = env('KEYCLOAK_BASE_URL') . '/realms/' . env('KEYCLOAK_REALM') . '/protocol/openid-connect/token';
+
+            $credentials = [
+                'username' => $username,
+                'password' => $password,
+                'client_id' => env('KEYCLOAK_CLIENT_ID'),
+                'client_secret' => env('KEYCLOAK_CLIENT_SECRET'),
+                'grant_type' => 'password',
+            ];
+
+            $response = Http::asForm()->post($authUrl, $credentials);
+            $responseData = $response->json();
+
+            return $responseData;
+        } catch (Exception $e) {
+            throw new Exception($e->getMessage());
+        }
+    }
+
+    public function logout(string $token): bool
+    {
+        try {
+            $authUrl = env('KEYCLOAK_BASE_URL') . '/realms/' . env('KEYCLOAK_REALM') . '/protocol/openid-connect/logout';
+
+            $response = Http::withHeaders([
+                'Authorization' => 'Bearer ' . $token,
+            ])->post($authUrl);
+
+            if ($response->status() === 200) {
+                return true;
+            }
+
+            return false;
+        } catch (Exception $e) {
+            throw new Exception($e->getMessage());
+        }
+    }
+
+    public function me(string $token, string $id): mixed
+    {
+        try {
+            $authUrl = env('KEYCLOAK_BASE_URL') . '/realms/' . env('KEYCLOAK_REALM') . '/users/' . $id;
+
+            $response = Http::withHeaders([
+                'Authorization' => 'Bearer ' . $token,
+            ])->post($authUrl);
+
+            $responseData = $response->json();
+            dd($responseData);
+
+        } catch (Exception $e) {
+            throw new Exception($e->getMessage());
+        }
+    }
+
+    private function getServiceToken(): string
+    {
+        try {
+            $authUrl = env('KEYCLOAK_BASE_URL') . '/realms/' . env('KEYCLOAK_REALM') . '/protocol/openid-connect/token';
+
+            $credentials = [
+                'client_secret' => env('KEYCLOAK_CLIENT_SECRET'),
+                'client_id' => env('KEYCLOAK_CLIENT_ID'),
+                'grant_type' => 'client_credentials',
+            ];
+
+            $response = Http::asForm()->post($authUrl, $credentials);
+            $responseData = $response->json();
+
+            return $responseData['access_token'];
+
+        } catch (Exception $e) {
+            throw new Exception($e->getMessage());
+        }
+    }
+
+
+    private function makeUrl(string $path): string
+    {
+        return env('KEYCLOAK_BASE_URL') . '/admin/realms/' . env('KEYCLOAK_REALM') . $path;
+    }
+}

--- a/app/Keycloak/KeycloakFacade.php
+++ b/app/Keycloak/KeycloakFacade.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Keycloak;
+
+use Illuminate\Support\Facades\Facade;
+
+class KeycloakFacade extends Facade {
+    protected static function getFacadeAccessor(): string
+    {
+        return 'keycloak';
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -21,8 +21,7 @@ class User extends Authenticatable
         'email',
         'registry_id',
         'provider',
-        'provider_sub',
-        'email_verified',
+        'keycloak_id',
     ];
 
     /**
@@ -32,7 +31,6 @@ class User extends Authenticatable
      */
     protected $hidden = [
         'provider',
-        'provider_sub',
     ];
 
     /**
@@ -41,7 +39,6 @@ class User extends Authenticatable
      * @var array<string, string>
      */
     protected $casts = [
-        'email_verified' => 'boolean',
     ];
 
     public function permissions(): BelongsToMany

--- a/app/Providers/KeycloakServiceProvider.php
+++ b/app/Providers/KeycloakServiceProvider.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Providers;
+
+use App\Keycloak\Keycloak;
+
+use Illuminate\Support\ServiceProvider;
+
+class KeycloakServiceProvider extends ServiceProvider
+{
+    /**
+     * Register services
+     * 
+     * @return void
+     */
+    public function register(): void
+    {
+        //
+    }
+
+    /**
+     * Bootstrap services.
+     * 
+     * @return void
+     */
+    public function boot(): void
+    {
+        $this->app->bind('keycloak', function() {
+            return new Keycloak();
+        });
+    }
+}

--- a/config/app.php
+++ b/config/app.php
@@ -171,6 +171,7 @@ return [
         Laravel\Socialite\SocialiteServiceProvider::class,
         \SocialiteProviders\Manager\ServiceProvider::class,
         Hdruk\LaravelMjml\Providers\LaravelMjmlServiceProvider::class,
+        App\Providers\KeycloakServiceProvider::class,
     ])->toArray(),
 
     /*
@@ -185,7 +186,7 @@ return [
     */
 
     'aliases' => Facade::defaultAliases()->merge([
-        // 'Example' => App\Facades\Example::class,
+        'Keycloak' => App\Keycloak\KeycloakFacade::class,
     ])->toArray(),
 
 ];

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -26,9 +26,8 @@ class UserFactory extends Factory
         return [
             'name' => fake()->name(),
             'email' => fake()->unique()->safeEmail(),
-            'email_verified' => fake()->randomElement([0, 1]),
             'provider' => fake()->word(),
-            'provider_sub' => Str::random(40),
+            'keycloak_id' => Str::random(50),
         ];
     }
 }

--- a/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/database/migrations/2014_10_12_000000_create_users_table.php
@@ -18,8 +18,7 @@ return new class extends Migration
             $table->string('password')->nullable()->default(null);
             $table->bigInteger('registry_id')->nullable()->default(null);
             $table->string('provider', 255)->nullable()->default('');
-            $table->string('provider_sub', 255);
-            $table->tinyInteger('email_verified')->default(0);
+            $table->string('keycloak_id', 255)->nullable()->default(null);
             $table->timestamps();
         });
     }

--- a/routes/api.php
+++ b/routes/api.php
@@ -28,8 +28,10 @@ use Illuminate\Support\Facades\Route;
 | be assigned to the "api" middleware group. Make something great!
 |
 */
-Route::get('auth/redirect', [AuthController::class, 'loginKeycloak']);
-Route::get('auth/callback', [AuthController::class, 'loginKeycloakCallback']);
+
+Route::post('auth/login', [AuthController::class, 'login']);
+Route::post('auth/register', [AuthController::class, 'register']);
+Route::post('auth/logout', [AuthController::class, 'logout']);
 Route::get('auth/me', [AuthController::class, 'me']);
 
 Route::post('v1/query', [QueryController::class, 'query']);


### PR DESCRIPTION
  Tests:    56 passed (184 assertions)
  Duration: 24.90s

![image](https://github.com/HDRUK/speedi-as-api/assets/117099666/0e6d8771-61d2-40c9-bf2c-e03a985b7765)


Extends what I did yesterday so that we can continue to use the registry sign-up/on form, rather than redirect to keycloak. This just wraps the functionality via our api.