### PR TITLE
feat(SOURSD-832): Extend user, org and custodian project endpoints for table views

### DIFF
--- a/app/Http/Controllers/Api/V1/CustodianController.php
+++ b/app/Http/Controllers/Api/V1/CustodianController.php
@@ -603,7 +603,7 @@ class CustodianController extends Controller
 
         $projects = Project::searchViaRequest()
           ->applySorting()
-          ->with('approvals')
+          ->with(['approvals', 'organisations'])
           ->filterWhen('approved', function ($query, $value) {
               if ($value) {
                   $query->whereHas('approvals');
@@ -635,6 +635,7 @@ class CustodianController extends Controller
           ->whereHas('custodians', function ($query) use ($custodianId) {
               $query->where('custodians.id', $custodianId);
           })
+          ->withCount('projectUsers')
           ->paginate((int)$this->getSystemConfig('PER_PAGE'));
 
         if ($projects) {

--- a/app/Http/Controllers/Api/V1/OrganisationController.php
+++ b/app/Http/Controllers/Api/V1/OrganisationController.php
@@ -801,7 +801,7 @@ class OrganisationController extends Controller
     {
         $projects = Project::searchViaRequest()
           ->applySorting()
-          ->with(['approvals'])
+          ->with(['approvals', 'organisations'])
           ->filterWhen('approved', function ($query, $approved) {
               if ($approved) {
                   $query->whereHas('approvals');
@@ -812,6 +812,7 @@ class OrganisationController extends Controller
           ->whereHas('organisations', function ($query) use ($organisationId) {
               $query->where('organisations.id', $organisationId);
           })
+          ->withCount('projectUsers')
           ->paginate((int)$this->getSystemConfig('PER_PAGE'));
 
         if ($projects) {

--- a/app/Http/Controllers/Api/V1/UserController.php
+++ b/app/Http/Controllers/Api/V1/UserController.php
@@ -745,7 +745,10 @@ class UserController extends Controller
             ->pluck('project_id')
             ->toArray();
 
-        $projects = Project::whereIn('id', $projectIds)->get();
+        $projects = Project::whereIn('id', $projectIds)
+            ->withCount('projectUsers')
+            ->with('organisations')
+            ->paginate((int)$this->getSystemConfig('PER_PAGE'));;
         return $this->OKResponse($projects);
     }
 


### PR DESCRIPTION
Paginate user projects, and add organisations and user counts to all 3 endpoints.

Contributes to https://hdruk.atlassian.net/browse/SOURSD-832 and supports https://github.com/HDRUK/speedi-as-web/pull/194