### PR TITLE
fix(REGISTRY-2016): return only own user for user entities

### DIFF
--- a/app/Http/Controllers/Api/V1/ProjectController.php
+++ b/app/Http/Controllers/Api/V1/ProjectController.php
@@ -405,6 +405,7 @@ class ProjectController extends Controller
      */
     public function getProjectUsers(GetProjectUsers $request, int $id): JsonResponse
     {
+        $loggedInUserId = $request->user();
 
         $projectUsers = ProjectHasUser::with([
             'registry.user',
@@ -421,6 +422,11 @@ class ProjectController extends Controller
                 $query->searchViaRequest()
                     ->filterByState()
                     ->with("modelState");
+            })
+            ->whereHas('registry.user', function($query) use ($loggedInUserId) {
+                if($loggedInUserId->user_group === User::GROUP_USERS) {
+                    $query->where('id', $loggedInUserId->id);
+                }
             })
             ->whereHas('affiliation.organisation', function ($query) {
                 /** @phpstan-ignore-next-line */


### PR DESCRIPTION
https://hdruk.atlassian.net/browse/REGISTRY-2016

Getting safe people for user entity should return only that user.