### PR TITLE
fix(REGISTRY-1712): Sponsor email not sent on newly invited org

### DIFF
--- a/app/RegistryManagementController/RegistryManagementController.php
+++ b/app/RegistryManagementController/RegistryManagementController.php
@@ -277,6 +277,7 @@ class RegistryManagementController
                 'is_delegate' => $user['is_delegate'] ?? 0,
                 'role' => $user['role'] ?? null,
                 'invited_by' => $user['invited_by'] ?? null,
+                'is_sro' => $user['is_sro'] ?? 1,
             ];
 
             if ($strictCreate) {


### PR DESCRIPTION
Relationship not being created if it was a new custodian invited, so changed logic.

The email being sent relies on:

```
$users = User::query()
            ->where([
                'organisation_id' => $organisationId,
                'is_delegate' => 1
            ])
            ->select(['id'])
            ->get();

        if ($users->isEmpty()) {
            $users = User::query()
                ->where([
                    'organisation_id' => $organisationId,
                    'is_sro' => 1
                ])
                ->select(['id'])
                ->get();
        }
```
is_delegate or is_sro were being set during a unclaimed user being created, it seems sensible to default to is_sro

<img width="1088" height="424" alt="image" src="https://github.com/user-attachments/assets/394c5052-9c33-4b04-b24b-beebf732ecf6" />

