### PR TITLE
feat(REGISTRY-2465): Bulk custodian users

### DIFF
--- a/app/Http/Controllers/Api/V1/CustodianUserController.php
+++ b/app/Http/Controllers/Api/V1/CustodianUserController.php
@@ -8,6 +8,7 @@ use Exception;
 use TriggerEmail;
 use App\Models\Permission;
 use Illuminate\Http\Response;
+use App\Http\Traits\Responses;
 use Illuminate\Http\Request;
 use App\Models\Custodian;
 use App\Models\CustodianUser;
@@ -25,6 +26,7 @@ class CustodianUserController extends Controller
 {
     
     use NotificationCustodianManager;
+    use Responses;
 
     /**
      * @OA\Get(
@@ -289,19 +291,8 @@ class CustodianUserController extends Controller
             $input = $request->all();
             $custodianKey = $request->header('x-client-id', null);
 
-            if (!$custodianKey) {
-                return response()->json([
-                    'message' => 'you must provide your Custodian key',
-                ], Response::HTTP_UNAUTHORIZED);
-            }
             
             $custodianId = Custodian::where('client_id', $custodianKey)->first()->id;
-
-            if (! $custodianId) {
-                 return response()->json([
-                    'message' => 'no known custodian matches the credentials provided',
-                ], Response::HTTP_UNAUTHORIZED);
-            }
 
             $createdUserIds = [];
 
@@ -345,9 +336,7 @@ class CustodianUserController extends Controller
                 $permission = Permission::where('name', $userInput['permission'])->first();
 
                 if (!$permission) {
-                    return response()->json([
-                        'message' => 'Invalid permission provided'
-                    ], Response::HTTP_UNPROCESSABLE_ENTITY);
+                    return $this->UnprocessableContent('Invalid permission provided');
                 }
 
                 CustodianUserHasPermission::create([
@@ -357,12 +346,11 @@ class CustodianUserController extends Controller
             }
 
 
-
-           return response()->json([
-            'message' => 'completed',
+        return $this->CreatedResponse([
             'created_user_ids' => $createdUserIds,
             'skipped' => $skippedUsers,
-        ], 201);
+        ]);
+
 
         } catch (Exception $e) {
             throw new Exception($e->getMessage());

--- a/app/Http/Controllers/Api/V1/CustodianUserController.php
+++ b/app/Http/Controllers/Api/V1/CustodianUserController.php
@@ -7,7 +7,9 @@ use Keycloak;
 use Exception;
 use TriggerEmail;
 use App\Models\Permission;
+use Illuminate\Http\Response;
 use Illuminate\Http\Request;
+use App\Models\Custodian;
 use App\Models\CustodianUser;
 use Illuminate\Http\JsonResponse;
 use App\Http\Controllers\Controller;
@@ -21,6 +23,7 @@ use App\Traits\Notifications\NotificationCustodianManager;
 
 class CustodianUserController extends Controller
 {
+    
     use NotificationCustodianManager;
 
     /**
@@ -227,6 +230,145 @@ class CustodianUserController extends Controller
             throw new Exception($e->getMessage());
         }
     }
+
+
+    /**
+     * @OA\Post(
+     *      path="/api/v1/custodian_users/bulk",
+     *      summary="Create multiple CustodianUser entries",
+     *      description="Create multiple CustodianUser entries",
+     *      tags={"CustodianUser"},
+     *      security={{"bearerAuth":{}}},
+     *      @OA\RequestBody(
+     *          required=true,
+     *          description="Array of CustodianUser definitions",
+     *          @OA\JsonContent(
+     *              type="object",
+     *              @OA\Property(
+     *                  property="users",
+     *                  type="array",
+     *                  @OA\Items(
+     *                      @OA\Property(property="first_name", type="string", example="John"),
+     *                      @OA\Property(property="last_name", type="string", example="Doe"),
+     *                      @OA\Property(property="email", type="string", example="john@example.com"),
+     *                      @OA\Property(
+     *                      property="permission",
+     *                      type="string",
+     *                       enum={"CUSTODIAN_ADMIN","CUSTODIAN_APPROVER"},
+     *                       example="CUSTODIAN_ADMIN"
+     *                      )
+     *                  )
+     *              )
+     *          ),
+     *      ),
+     *      @OA\Response(
+     *          response=201,
+     *          description="Success",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string", example="success"),
+     *              @OA\Property(
+     *                  property="data",
+     *                  type="array",
+     *                  @OA\Items(type="integer", example=1)
+     *              )
+     *          )
+     *      ),
+     *      @OA\Response(
+     *          response=500,
+     *          description="Error",
+     *          @OA\JsonContent(
+     *              @OA\Property(property="message", type="string", example="error")
+     *          )
+     *      )
+     * )
+     */
+    public function bulkStore(Request $request): JsonResponse
+    {
+        try {
+            
+            $input = $request->all();
+            $custodianKey = $request->header('x-client-id', null);
+
+            if (!$custodianKey) {
+                return response()->json([
+                    'message' => 'you must provide your Custodian key',
+                ], Response::HTTP_UNAUTHORIZED);
+            }
+            
+            $custodianId = Custodian::where('client_id', $custodianKey)->first()->id;
+
+            if (! $custodianId) {
+                 return response()->json([
+                    'message' => 'no known custodian matches the credentials provided',
+                ], Response::HTTP_UNAUTHORIZED);
+            }
+
+            $createdUserIds = [];
+
+            $createdUserIds = [];
+            $skippedUsers = [];
+
+            foreach ($input['users'] as $userInput) {
+
+                if (
+                    !isset($userInput['permission']) ||
+                    !in_array($userInput['permission'], ['CUSTODIAN_ADMIN', 'CUSTODIAN_APPROVER'])
+                ) {
+                    return response()->json([
+                        'message' => 'permission must be either CUSTODIAN_ADMIN or CUSTODIAN_APPROVER'
+                    ], Response::HTTP_UNPROCESSABLE_ENTITY);
+                }
+
+                $existingUser = CustodianUser::where('email', $userInput['email'])
+                    ->where('custodian_id', $custodianId)
+                    ->first();
+
+                if ($existingUser) {
+                    $skippedUsers[] = [
+                        'email' => $userInput['email'],
+                        'reason' => 'already exists'
+                    ];
+                    continue;
+                }
+
+                $user = CustodianUser::create([
+                    'first_name'   => $userInput['first_name'],
+                    'last_name'    => $userInput['last_name'],
+                    'email'        => $userInput['email'],
+                    'provider'     => '',
+                    'keycloak_id'  => '',
+                    'custodian_id' => $custodianId,
+                ]);
+
+                $createdUserIds[] = $user->id;
+
+                $permission = Permission::where('name', $userInput['permission'])->first();
+
+                if (!$permission) {
+                    return response()->json([
+                        'message' => 'Invalid permission provided'
+                    ], Response::HTTP_UNPROCESSABLE_ENTITY);
+                }
+
+                CustodianUserHasPermission::create([
+                    'custodian_user_id' => $user->id,
+                    'permission_id'     => $permission->id,
+                ]);
+            }
+
+
+
+           return response()->json([
+            'message' => 'completed',
+            'created_user_ids' => $createdUserIds,
+            'skipped' => $skippedUsers,
+        ], 201);
+
+        } catch (Exception $e) {
+            throw new Exception($e->getMessage());
+        }
+    }
+
 
     /**
      * @OA\Put(

--- a/app/Http/Traits/Responses.php
+++ b/app/Http/Traits/Responses.php
@@ -113,4 +113,12 @@ trait Responses
         ], Response::HTTP_NO_CONTENT);
     }
 
+
+    public function UnprocessableContent(string $message): JsonResponse
+    {
+        return response()->json([
+            'message' => $message,
+        ], Response::HTTP_UNPROCESSABLE_ENTITY);
+    }
+
 }

--- a/database/seeders/EmailTemplatesSeeder.php
+++ b/database/seeders/EmailTemplatesSeeder.php
@@ -159,7 +159,7 @@ class EmailTemplatesSeeder extends Seeder
                                 <mj-text align="left" padding="20px 0px 20px 0px">
                                   [[custodian.name]]
                                   <div><br></div>
-                                  You"ve been invited to sign-up as a trusted Data Custodian, for the [[env(APP_NAME)]].
+                                  You\'ve been invited to sign-up as a trusted Data Custodian, for the [[env(APP_NAME)]].
                                   <div><br></div>
                                   ' . $this->whatIsBlurb . '
                                   <div><br></div>

--- a/database/seeders/EmailTemplatesSeeder.php
+++ b/database/seeders/EmailTemplatesSeeder.php
@@ -257,7 +257,7 @@ class EmailTemplatesSeeder extends Seeder
                                 <mj-text align="left" padding="20px 0px 20px 0px">
                                   ' . $this->whatIsBlurb . '
                                   <div><br></div>
-                                  You"ve been added to the [[env(APP_NAME)]] by [[custodian.name]]. Please follow the link below to make a profile. [[custodian.name]] will use your [[env(APP_NAME)]] profile to validate you under the "safe people" criteria of the Five Safes.
+                                  You\'ve been added to the [[env(APP_NAME)]] by [[custodian.name]]. Please follow the link below to make a profile. [[custodian.name]] will use your [[env(APP_NAME)]] profile to validate you under the "safe people" criteria of the Five Safes.
                                   <div><br/></div>
                                   ' . $this->supportFooter . '
                                 </mj-text>
@@ -296,7 +296,7 @@ class EmailTemplatesSeeder extends Seeder
 
                                   [[users.first_name]] [[users.last_name]]
                                   <div><br></div>
-                                  You"ve been invited to sign-up as a User (researcher/innovator) within the [[env(APP_NAME)]] by [[organisation.organisation_name]].
+                                  You\'ve been invited to sign-up as a User (researcher/innovator) within the [[env(APP_NAME)]] by [[organisation.organisation_name]].
                                   <div><br></div>
                                   ' . $this->whatIsBlurb . '
                                   <div><br></div>
@@ -339,7 +339,7 @@ class EmailTemplatesSeeder extends Seeder
 
                                   [[users.first_name]] [[users.last_name]]
                                   <div><br></div>
-                                  You"ve been invited to sign-up as an Approver within the [[env(APP_NAME)]] for the Data Custodian: [[custodian.name]].
+                                  You\'ve been invited to sign-up as an Approver within the [[env(APP_NAME)]] for the Data Custodian: [[custodian.name]].
                                   <div><br></div>
                                   ' . $this->whatIsBlurb . '
                                   <div><br></div>
@@ -382,7 +382,7 @@ class EmailTemplatesSeeder extends Seeder
 
                                   [[users.first_name]] [[users.last_name]]
                                   <div><br></div>
-                                  You"ve been invited to sign-up as an Administrator within the [[env(APP_NAME)]] for the Data Custodian: [[custodian.name]].
+                                  You\'ve been invited to sign-up as an Administrator within the [[env(APP_NAME)]] for the Data Custodian: [[custodian.name]].
                                   <div><br></div>
                                   ' . $this->whatIsBlurb . '
                                   <div><br></div>
@@ -424,7 +424,7 @@ class EmailTemplatesSeeder extends Seeder
                                 <mj-text align="left" padding="20px 0px 20px 0px">
                                   ' . $this->whatIsBlurb . '
                                   <div><br></div>
-                                  You"ve been added to the [[env(APP_NAME)]] by [[custodian.name]]. Please follow the link below to make a profile. [[custodian.name]] will use your [[env(APP_NAME)]] profile to validate you under the "safe people" criteria of the Five Safes.
+                                  You\'ve been added to the [[env(APP_NAME)]] by [[custodian.name]]. Please follow the link below to make a profile. [[custodian.name]] will use your [[env(APP_NAME)]] profile to validate you under the "safe people" criteria of the Five Safes.
                                   <div><br></div>
                                   ' . $this->supportFooter . '
                                 </mj-text>
@@ -560,7 +560,7 @@ class EmailTemplatesSeeder extends Seeder
           ],
           [
             'identifier' => 'researcher_without_organisation_invite',
-            'subject' => 'You"ve been invited to join the Researcher Registry',
+            'subject' => 'You\'ve been invited to join the Researcher Registry',
             'body' => '<mjml>
                         ' . $this->mjmlHead . '
                         <mj-body background-color="#efeeea" width="600px" >
@@ -569,7 +569,7 @@ class EmailTemplatesSeeder extends Seeder
                               <mj-section background-repeat="repeat" background-size="auto" background-position="top center" border="none" direction="ltr" text-align="left" padding="0px 0px 0px 0px" >
                                 <mj-column border="none" vertical-align="top" padding="0px 0px 0px 0px" >
                                   <mj-text align="left" padding="10px 25px 10px 25px" >
-                                    [[users.first_name]] [[users.last_name]]<br><br>You"ve been invited to sign-up as a Researcher within the [[env(APP_NAME)]] Registry system. To begin your sign-up process, please 
+                                    [[users.first_name]] [[users.last_name]]<br><br>You\'ve been invited to sign-up as a Researcher within the [[env(APP_NAME)]] Registry system. To begin your sign-up process, please 
                                     click the button below.
                                     <div><br></div>
                                     ' . $this->supportFooter . '
@@ -604,7 +604,7 @@ class EmailTemplatesSeeder extends Seeder
                                 <mj-text align="left" padding="20px 0px 20px 0px">
                                   [[users.first_name]] [[users.last_name]]
                                   <br><br>
-                                  You"ve been invited to sign-up as a delegate user within the [[env(APP_NAME)]], by [[organisation.organisation_name]].
+                                  You\'ve been invited to sign-up as a delegate user within the [[env(APP_NAME)]], by [[organisation.organisation_name]].
                                   <div><br></div>
                                   ' . $this->whatIsBlurb . '
                                   <div><br></div>
@@ -737,7 +737,7 @@ class EmailTemplatesSeeder extends Seeder
                               <mj-column border="none" vertical-align="top" padding="0px 0px 0px 0px">
                                 <mj-text align="left" padding="20px 0px 20px 0px">
 
-                                  You"ve been added to [[project_name]] in the [[env(APP_NAME)]]. You can follow the link below to see your project list and follow your validation status.
+                                  You\'ve been added to [[project_name]] in the [[env(APP_NAME)]]. You can follow the link below to see your project list and follow your validation status.
                                   <div><br></div>
                                   ' . $this->supportFooter . '
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -63,6 +63,8 @@ use App\Http\Controllers\Api\V1\CustodianHasProjectOrganisationController;
 
 Route::middleware(['check.custodian.access', 'verify.signed.payload'])->post('v1/query', [QueryController::class, 'query']);
 Route::middleware(['check.custodian.access', 'verify.signed.payload'])->post('v1/validate', [UserController::class, 'validateUserRequest']);
+Route::middleware(['check.custodian.access', 'verify.signed.payload'])->post('v1/custodian_users/bulk', [CustodianUserController::class, 'bulkStore']);
+
 
 // --- AUTH ---
 Route::middleware('api')->get('auth/me', [AuthController::class, 'me']);


### PR DESCRIPTION
New custodian endpoint using the signed payload headers for manual onboarding.

This allows bulk users to be imported, the permissions are the human readable enum rather than the numeric values, there is validation allowing either one or the other and if a user exists it is skipped and the user notified in the response.
<img width="1280" height="752" alt="image" src="https://github.com/user-attachments/assets/2983aa35-04cf-4c26-b381-ce7fe0f1374e" />
