### PR TITLE
fix(REGISTRY-2450): Return projectOrganisation.project for header

### DIFF
--- a/app/Http/Controllers/Api/V1/CustodianHasProjectOrganisationController.php
+++ b/app/Http/Controllers/Api/V1/CustodianHasProjectOrganisationController.php
@@ -204,8 +204,9 @@ class CustodianHasProjectOrganisationController extends Controller
             }
 
             $puhca = CustodianHasProjectOrganisation::with([
-                'modelState.state',
-                'projectOrganisation.organisation'
+                'modelState.state',                
+                'projectOrganisation.organisation',
+                'projectOrganisation.project'
             ])
                 ->where([
                     'project_has_organisation_id' => $projectOrganisationId,


### PR DESCRIPTION
Return projectOrganisation.project, used to display project title in header