### PR TITLE
fix(REGISTRY-2165): observer not running for affilation emails to trigger

### DIFF
--- a/.github/workflows/dev_deployment.yaml
+++ b/.github/workflows/dev_deployment.yaml
@@ -4,7 +4,7 @@ run-name: ${{ github.actor }} triggered deploy to DEV pipeline
 on:
   push:
     branches:
-      - fix/REGISTRY-2165 # override for branch deployment
+      - dev # override for branch deployment
 
 env:
   PROJECT_ID: '${{ secrets.PROJECT_ID }}'
@@ -26,7 +26,7 @@ jobs:
         id: checkout
         uses: actions/checkout@v4
         with:
-          ref: fix/REGISTRY-2165 # override for branch deployment
+          ref: dev # override for branch deployment
 
       - name: Read VERSION file
         id: getversion
@@ -76,7 +76,7 @@ jobs:
         id: checkout
         uses: actions/checkout@v4
         with:
-          ref: fix/REGISTRY-2165 # override for branch deployment
+          ref: dev # override for branch deployment
 
       - name: Google Auth
         id: auth

--- a/.github/workflows/dev_deployment.yaml
+++ b/.github/workflows/dev_deployment.yaml
@@ -4,7 +4,7 @@ run-name: ${{ github.actor }} triggered deploy to DEV pipeline
 on:
   push:
     branches:
-      - dev # override for branch deployment
+      - fix/REGISTRY-2165 # override for branch deployment
 
 env:
   PROJECT_ID: '${{ secrets.PROJECT_ID }}'
@@ -26,7 +26,7 @@ jobs:
         id: checkout
         uses: actions/checkout@v4
         with:
-          ref: dev # override for branch deployment
+          ref: fix/REGISTRY-2165 # override for branch deployment
 
       - name: Read VERSION file
         id: getversion
@@ -76,7 +76,7 @@ jobs:
         id: checkout
         uses: actions/checkout@v4
         with:
-          ref: dev # override for branch deployment
+          ref: fix/REGISTRY-2165 # override for branch deployment
 
       - name: Google Auth
         id: auth

--- a/app/Http/Controllers/Api/V1/AffiliationController.php
+++ b/app/Http/Controllers/Api/V1/AffiliationController.php
@@ -613,9 +613,9 @@ class AffiliationController extends Controller
                 'verification_confirmed_at' => Carbon::now(),
             ];
 
-            $updatedAffiliation = Affiliation::where('id', $affiliation->id)->update($array);
+            $affiliation->update($array);
 
-            return $this->OKResponse($updatedAffiliation);
+            return $this->OKResponse($affiliation);
         } catch (Exception $e) {
             throw new Exception($e->getMessage());
         }

--- a/app/Observers/AffiliationObserver.php
+++ b/app/Observers/AffiliationObserver.php
@@ -64,7 +64,7 @@ class AffiliationObserver
     {
         return filled($affiliation->member_id)
             && filled($affiliation->relationship)
-            && filled($affiliation->from) && $affiliation->is_verified === 1;
+            && filled($affiliation->from) && (bool) $affiliation->is_verified;
     }
 
     private function sendDelegateEmails(Affiliation $affiliation): void


### PR DESCRIPTION
Update observer wont run on  Affiliation::where('id', $affiliation->id)->update($array); also we already have the affiliation at this point... 

the check was a lil too strict as its a true not a 1 so === returns false