### PR TITLE
feat(REGISTRY-2774): Add "People Services/Human Resources" to Departments

### DIFF
--- a/app/Console/Commands/Oneoff/REG2774_20260521_AddingHRToDepartments.php
+++ b/app/Console/Commands/Oneoff/REG2774_20260521_AddingHRToDepartments.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Console\Commands\Oneoff;
+
+use Exception;
+use Illuminate\Console\Command;
+use App\Models\Department;
+use Illuminate\Support\Facades\Log;
+
+class REG2774_20260521_AddingHRToDepartments extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:add-hr-to-departments';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'One-off command adding HR to departments. Not required to be run if DepartmentSeeder has been run';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        try {
+            Department::updateOrCreate([
+                'name' => 'People Services and Human Resources',
+                'category' => 'Cross-Cutting Departments',
+            ]);
+
+            return Command::SUCCESS;
+        } catch (Exception $e) {
+            $this->error('An error occurred: ' . $e->getMessage());
+            $this->newLine();
+            $this->line('Stack trace:');
+            $this->line($e->getTraceAsString());
+
+
+            Log::error('Command adding HR to departments', [
+                'message' => $e->getMessage()
+            ]);
+
+            return Command::FAILURE;
+        }
+    }
+}

--- a/app/Console/Commands/Oneoff/REG2774_20260521_AddingHRToDepartments.php
+++ b/app/Console/Commands/Oneoff/REG2774_20260521_AddingHRToDepartments.php
@@ -14,7 +14,7 @@ class REG2774_20260521_AddingHRToDepartments extends Command
      *
      * @var string
      */
-    protected $signature = 'app:add-hr-to-departments';
+    protected $signature = 'oneoff:add-hr-to-departments';
 
     /**
      * The console command description.

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -26,6 +26,7 @@ class Kernel extends ConsoleKernel
     protected function commands(): void
     {
         $this->load(__DIR__.'/Commands');
+        $this->load(__DIR__.'/Commands/Oneoff');
 
         require base_path('routes/console.php');
     }

--- a/database/seeders/DepartmentSeeder.php
+++ b/database/seeders/DepartmentSeeder.php
@@ -43,6 +43,7 @@ class DepartmentSeeder extends Seeder
                 'Finance and Grants Management',
                 'Communications and Public Engagement',
                 'Ethics and Compliance',
+                'People Services and Human Resources',
             ],
         ];
 


### PR DESCRIPTION
Update DepartmentSeeder with new entry. 
Add a command to add the entry instead where more appropriate

Created a new `Oneoff` subdirectory for commands that should only be run once (typically for data edits) to separate them from more regular or reused commands.

## Release actions:
- [x] Run `php artisan oneoff:add-hr-to-departments` in dev
- [x] Run `php artisan oneoff:add-hr-to-departments` in preprod (completed by Sam 22/05)
- [x] Run `php artisan oneoff:add-hr-to-departments` in prod (completed by Sam 22/05)