### PR TITLE
feat(REGISTRY-2673): Update default validation checks

### DIFF
--- a/app/Console/Commands/Oneoff/REG2673_20260521_ResetDefaultValidationChecks.php
+++ b/app/Console/Commands/Oneoff/REG2673_20260521_ResetDefaultValidationChecks.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Console\Commands\Oneoff;
+
+use Exception;
+use Illuminate\Console\Command;
+use App\Models\ValidationCheck;
+use Database\Seeders\ValidationCheckSeeder;
+use Illuminate\Support\Facades\Log;
+
+class REG2673_20260521_ResetDefaultValidationChecks extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'oneoff:reset-default-validation-checks';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'One-off command to reset default validation checks';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        try {
+            ValidationCheck::where('custodian_id', null)->delete();
+
+            $vcs = new ValidationCheckSeeder();
+            $vcs->run();
+
+            return Command::SUCCESS;
+        } catch (Exception $e) {
+            $this->error('An error occurred: ' . $e->getMessage());
+            $this->newLine();
+            $this->line('Stack trace:');
+            $this->line($e->getTraceAsString());
+
+
+            Log::error('Command adding HR to departments', [
+                'message' => $e->getMessage()
+            ]);
+
+            return Command::FAILURE;
+        }
+    }
+}

--- a/app/Models/Organisation.php
+++ b/app/Models/Organisation.php
@@ -532,12 +532,28 @@ class Organisation extends Model
     {
         return [
             [
-                'name' => 'organisation_aligned_with_sde_network',
-                'description' => 'Is the Organisation aligned with the SDE network?',
+                'name' => 'sro_identity_verified',
+                'description' => 'Contact details tab: Verify SRO identity',
             ],
             [
-                'name' => 'confidence_in_costs_and_profits_for_future_projects',
-                'description' => 'Are we confident costs would be met and profits realised for future projects?',
+                'name' => 'location_meets_requirements',
+                'description' => 'Contact details tab: Location meets project & policy requirements',
+            ],
+            [
+                'name' => 'digital_identifiers_verified',
+                'description' => 'Digital identifiers tab: Check validity & type (Public, Private, etc.)',
+            ],
+            [
+                'name' => 'website_due_diligence',
+                'description' => 'Sector size & website tab: Due diligence on website',
+            ],
+            [
+                'name' => 'security_minimum_requirements_met',
+                'description' => 'Data security compliance tab: Meets minimum requirements for project',
+            ],
+            [
+                'name' => 'signed_data_access_agreement',
+                'description' => 'Signed Data Access Agreement',
             ],
         ];
     }

--- a/app/Models/ProjectHasUser.php
+++ b/app/Models/ProjectHasUser.php
@@ -60,12 +60,29 @@ class ProjectHasUser extends Model
     {
         return [
             [
-                'name' => 'mandatory_training_complete',
-                'description' => 'Mandatory training has been completed',
+                'name' => 'no_conflists_of_interest',
+                'description' => 'Affiliations tab: No conflicts of interest',
             ],
             [
-                'name' => 'organisation_has_confirmed_the_user',
-                'description' => 'The organisation has confirmed the user',
+                'name' => 'previous_projects_with_us',
+                'description' => 'Projects tab: Previous sensitive data project with us in last 2 years at same affiliation?',
+            ],
+            [
+                'name' => 'international_transfer_rules',
+                'description' => 'Identity tab: If located outside of UK, check Project with GDPR international transfer rules',
+            ],
+            [
+                'name' => 'recent_training',
+                'description' => 'Training tab: Has completed required training within 3 years',
+            ],
+            [
+                'name' => 'dea_accredited',
+
+                'description' => 'Training tab: If DEA project, are they DEA accredited?',
+            ],
+            [
+                'name' => 'user_declaration',
+                'description' => 'Signed User Declaration submitted',
             ],
         ];
     }

--- a/app/Models/ProjectHasUser.php
+++ b/app/Models/ProjectHasUser.php
@@ -60,7 +60,7 @@ class ProjectHasUser extends Model
     {
         return [
             [
-                'name' => 'no_conflists_of_interest',
+                'name' => 'no_conflicts_of_interest',
                 'description' => 'Affiliations tab: No conflicts of interest',
             ],
             [
@@ -77,7 +77,6 @@ class ProjectHasUser extends Model
             ],
             [
                 'name' => 'dea_accredited',
-
                 'description' => 'Training tab: If DEA project, are they DEA accredited?',
             ],
             [

--- a/database/seeders/ValidationCheckSeeder.php
+++ b/database/seeders/ValidationCheckSeeder.php
@@ -19,6 +19,7 @@ class ValidationCheckSeeder extends Seeder
                 [
                     'name' => $check['name'],
                     'applies_to' => ProjectHasUser::class,
+                    'custodian_id' => null,
                 ],
                 [
                     'description' => $check['description'],
@@ -32,6 +33,7 @@ class ValidationCheckSeeder extends Seeder
                 [
                     'name' => $check['name'],
                     'applies_to' => Organisation::class,
+                    'custodian_id' => null,
                 ],
                 [
                     'description' => $check['description'],

--- a/tests/Feature/ValidationLogTest.php
+++ b/tests/Feature/ValidationLogTest.php
@@ -255,7 +255,7 @@ class ValidationLogTest extends TestCase
         $response->assertStatus(200);
         $responseData = $response['data'];
 
-        $checkName = 'mandatory_training_complete';
+        $checkName = 'no_conflicts_of_interest';
         $validationCheckId = ValidationCheck::where('name', $checkName)->value('id');
 
         $validationLog = collect($responseData)
@@ -323,7 +323,7 @@ class ValidationLogTest extends TestCase
         $response->assertStatus(200);
         $responseData = $response['data'];
 
-        $checkName = 'mandatory_training_complete';
+        $checkName = 'no_conflicts_of_interest';
         $validationCheckId = ValidationCheck::where('name', $checkName)->value('id');
 
         $validationLog = collect($responseData)
@@ -391,7 +391,7 @@ class ValidationLogTest extends TestCase
         $response->assertStatus(200);
         $responseData = $response['data'];
 
-        $checkName = 'mandatory_training_complete';
+        $checkName = 'no_conflicts_of_interest';
         $validationCheckId = ValidationCheck::where('name', $checkName)->value('id');
 
         $validationLog = collect($responseData)
@@ -550,7 +550,7 @@ class ValidationLogTest extends TestCase
         $response->assertJson(['data' => $expectedResponse]);
 
         // Pick one check to disable
-        $checkNameToDisable = 'mandatory_training_complete';
+        $checkNameToDisable = 'no_conflicts_of_interest';
         $validationCheckId = ValidationCheck::where('name', $checkNameToDisable)->value('id');
 
         $payload = [


### PR DESCRIPTION
Updates the default validation checks that will be added for new Custodians at time of creation. Does not back-port these checks to existing Custodians. 

## Actions for release
- [x] Run `php artisan oneoff:reset-default-validation-checks` on dev
- [x] Run `php artisan oneoff:reset-default-validation-checks` on preprod (completed by Sam 22/05)
- [x] Run `php artisan oneoff:reset-default-validation-checks` on prod (completed by Sam 22/05)