### PR TITLE
fix(REGISTRY-2787): Fix static route being consumed by dynamic route

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -197,13 +197,13 @@ Route::middleware('auth:api')
                 Route::delete('/{id}', 'destroy');
             });
 
-        Route::prefix('custodians/{custodianId}/validation_checks')
-            ->group(function () {
-                Route::get('/', 'getCustodianValidationChecks');
-            });
         Route::prefix('custodians/validation_checks')
             ->group(function () {
                 Route::post('/', 'createCustodianValidationChecks');
+            });
+        Route::prefix('custodians/{custodianId}/validation_checks')
+            ->group(function () {
+                Route::get('/', 'getCustodianValidationChecks');
             });
     });
 


### PR DESCRIPTION

https://github.com/user-attachments/assets/39b49b99-97eb-4446-97cf-c46c3440e9c2

Fixes adding manual checks. Caused by a static route being defined _after_ a dynamic route. Static routes need to be defined first in the order, as dynamic routes consume anything beyond the binding. In this instance, the {custodianId} was seen as /validation_checks and it just never fired.