### PR TITLE
feat(REGISTRY-2826): Filter activity logs by custodian

### DIFF
--- a/.github/workflows/dev_deployment.yaml
+++ b/.github/workflows/dev_deployment.yaml
@@ -20,5 +20,5 @@ jobs:
     with:
       env: dev
       chart_path: chart/soursd-api/Chart.yaml
-      git_ref: dev
+      git_ref: feat/registry-2826
     secrets: inherit

--- a/.github/workflows/dev_deployment.yaml
+++ b/.github/workflows/dev_deployment.yaml
@@ -1,10 +1,10 @@
 name: Build and deploy to DEV
-run-name:  ${{ github.actor }} triggered deploy to DEV pipeline
+run-name: ${{ github.actor }} triggered deploy to DEV pipeline
 
 on:
   push:
     branches:
-      - dev
+      - feat/registry-2826
 
 jobs:
   build:

--- a/.github/workflows/dev_deployment.yaml
+++ b/.github/workflows/dev_deployment.yaml
@@ -1,10 +1,10 @@
 name: Build and deploy to DEV
-run-name: ${{ github.actor }} triggered deploy to DEV pipeline
+run-name:  ${{ github.actor }} triggered deploy to DEV pipeline
 
 on:
   push:
     branches:
-      - feat/registry-2826
+      - dev
 
 jobs:
   build:
@@ -20,5 +20,5 @@ jobs:
     with:
       env: dev
       chart_path: chart/soursd-api/Chart.yaml
-      git_ref: feat/registry-2826
+      git_ref: dev
     secrets: inherit

--- a/app/Http/Controllers/Api/V1/AuditLogController.php
+++ b/app/Http/Controllers/Api/V1/AuditLogController.php
@@ -135,6 +135,24 @@ class AuditLogController extends Controller
                     $activityLog->description = '';
                 }
 
+                if (
+                    in_array($loggedInUser->user_group, [User::GROUP_ORGANISATIONS, User::GROUP_CUSTODIANS]) &&
+                    $activityLog->properties !== null) {
+                    if (
+                        isset($activityLog->properties['old']) &&
+                        isset($activityLog->properties['old']['email'])
+                    ) {
+                        $activityLog->properties['old']['email'] = 'hidden';
+                    }
+
+                    if (
+                        isset($activityLog->properties['new']) &&
+                        isset($activityLog->properties['new']['email'])
+                    ) {
+                        $activityLog->properties['new']['email'] = 'hidden';
+                    }
+                }
+
                 return $activityLog;
             });
 

--- a/app/Http/Controllers/Api/V1/AuditLogController.php
+++ b/app/Http/Controllers/Api/V1/AuditLogController.php
@@ -68,10 +68,13 @@ class AuditLogController extends Controller
                             'causer_type' => get_class($user),
                         ])
                         ->whereIn('causer_id', $userIdsInThisCustodian);
-                })->orWhere([
-                    'causer_type' => get_class($user),
-                    'causer_id' => $user->id
+                })
+                ->orWhere(function ($q) use ($user) {
+                    $q->where([
+                        'causer_type' => get_class($user),
+                        'causer_id' => $user->id
                     ]);
+                });
             })
             ->whereJsonDoesntContainKey('properties->attributes->email')
             ->whereHasMorph('subject', self::ALLOWED_TYPES)

--- a/app/Http/Controllers/Api/V1/AuditLogController.php
+++ b/app/Http/Controllers/Api/V1/AuditLogController.php
@@ -68,14 +68,12 @@ class AuditLogController extends Controller
                             'causer_type' => get_class($user),
                         ])
                         ->whereIn('causer_id', $userIdsInThisCustodian);
-                })->orWhere(function ($q) use ($user) {
-                    $q->where([
-                        'causer_type' => get_class($user),
-                        'causer_id' => $user->id
-                        ])
-                        ->whereJsonDoesntContainKey('properties->attributes->email');
-                });
+                })->orWhere([
+                    'causer_type' => get_class($user),
+                    'causer_id' => $user->id
+                    ]);
             })
+            ->whereJsonDoesntContainKey('properties->attributes->email')
             ->whereHasMorph('subject', self::ALLOWED_TYPES)
             ->where(function ($query) {
                 $query->whereNull('causer_type')

--- a/app/Http/Controllers/Api/V1/AuditLogController.php
+++ b/app/Http/Controllers/Api/V1/AuditLogController.php
@@ -58,7 +58,7 @@ class AuditLogController extends Controller
 
         // This will show activity associated to the given user, caused either by the user themselves or by other
         // users in the same custodian group as the logged-in user. It will also show activity caused by the user on other subjects.
-        // It explicitly excludes logs where the user changes their email address
+        // It also masks email addresses in the properties of the activity log
         $logs = Activity::query()
             ->where(function ($query) use ($user, $userIdsInThisCustodian) {
                 $query->where(function ($q) use ($user, $userIdsInThisCustodian) {

--- a/app/Http/Controllers/Api/V1/AuditLogController.php
+++ b/app/Http/Controllers/Api/V1/AuditLogController.php
@@ -136,7 +136,7 @@ class AuditLogController extends Controller
                 if (isset($attributes['email'])) {
                     $attributes['email'] = '***';
                 }
-                $activityLog->properties = ['old' => $old, 'attributes' => $attributes];
+                $activityLog->properties = collect(['old' => $old, 'attributes' => $attributes]);
 
                 return $activityLog;
             });

--- a/app/Http/Controllers/Api/V1/AuditLogController.php
+++ b/app/Http/Controllers/Api/V1/AuditLogController.php
@@ -58,29 +58,22 @@ class AuditLogController extends Controller
 
         // This will show activity associated to the given user, caused either by the user themselves or by other
         // users in the same custodian group as the logged-in user. It will also show activity caused by the user on other subjects.
+        // It explicitly excludes logs where the user changes their email address
         $logs = Activity::query()
             ->where(function ($query) use ($user, $userIdsInThisCustodian) {
                 $query->where(function ($q) use ($user, $userIdsInThisCustodian) {
                     $q->where([
-                        'subject_type' => get_class($user),
-                        'subject_id' => $user->id,
-                        'causer_type' => get_class($user),
-                        'causer_id' => $user->id
-                    ])
-                    ->orWhere(function ($q2) use ($user, $userIdsInThisCustodian) {
-                        $q2->where([
                             'subject_type' => get_class($user),
                             'subject_id' => $user->id,
                             'causer_type' => get_class($user),
                         ])
-                        ->whereIn('causer_id', $userIdsInThisCustodian)
-                        ;
-                    })
-                    ;
-                    // ]);
+                        ->whereIn('causer_id', $userIdsInThisCustodian);
                 })->orWhere(function ($q) use ($user) {
-                    $q->where('causer_type', get_class($user))
-                        ->where('causer_id', $user->id);
+                    $q->where([
+                        'causer_type' => get_class($user),
+                        'causer_id' => $user->id
+                        ])
+                        ->whereJsonDoesntContainKey('properties->attributes->email');
                 });
             })
             ->whereHasMorph('subject', self::ALLOWED_TYPES)
@@ -133,24 +126,6 @@ class AuditLogController extends Controller
                     $activityLog->causer_id !== $loggedInUser->id
                 ) {
                     $activityLog->description = '';
-                }
-
-                if (
-                    in_array($loggedInUser->user_group, [User::GROUP_ORGANISATIONS, User::GROUP_CUSTODIANS]) &&
-                    $activityLog->properties !== null) {
-                    if (
-                        isset($activityLog->properties['old']) &&
-                        isset($activityLog->properties['old']['email'])
-                    ) {
-                        $activityLog->properties['old']['email'] = 'hidden';
-                    }
-
-                    if (
-                        isset($activityLog->properties['attributes']) &&
-                        isset($activityLog->properties['attributes']['email'])
-                    ) {
-                        $activityLog->properties['attributes']['email'] = 'hidden';
-                    }
                 }
 
                 return $activityLog;

--- a/app/Http/Controllers/Api/V1/AuditLogController.php
+++ b/app/Http/Controllers/Api/V1/AuditLogController.php
@@ -6,6 +6,7 @@ use App\Models\User;
 use App\Models\Affiliation;
 use App\Models\Organisation;
 use App\Models\ValidationLog;
+use App\Models\CustodianUser;
 use App\Http\Traits\Responses;
 use App\Traits\CommonFunctions;
 use App\Http\Controllers\Controller;
@@ -46,11 +47,37 @@ class AuditLogController extends Controller
             return $this->NotFoundResponse();
         }
 
+        $userIdsInThisCustodian = [];
+
+        if ($loggedInUser->custodian_user_id !== null) {
+            $custodianId = CustodianUser::where('id', $loggedInUser->custodian_user_id)->value('custodian_id');
+            $userIdsInThisCustodian = User::whereIn('custodian_user_id',
+                CustodianUser::where('custodian_id', $custodianId)->select('id')
+            )->pluck('id')->toArray();
+        }
+
+        // This will show activity associated to the given user, caused either by the user themselves or by other
+        // users in the same custodian group as the logged-in user. It will also show activity caused by the user on other subjects.
         $logs = Activity::query()
-            ->where(function ($query) use ($user) {
-                $query->where(function ($q) use ($user) {
-                    $q->where('subject_type', get_class($user))
-                        ->where('subject_id', $user->id);
+            ->where(function ($query) use ($user, $userIdsInThisCustodian) {
+                $query->where(function ($q) use ($user, $userIdsInThisCustodian) {
+                    $q->where([
+                        'subject_type' => get_class($user),
+                        'subject_id' => $user->id,
+                        'causer_type' => get_class($user),
+                        'causer_id' => $user->id
+                    ])
+                    ->orWhere(function ($q2) use ($user, $userIdsInThisCustodian) {
+                        $q2->where([
+                            'subject_type' => get_class($user),
+                            'subject_id' => $user->id,
+                            'causer_type' => get_class($user),
+                        ])
+                        ->whereIn('causer_id', $userIdsInThisCustodian)
+                        ;
+                    })
+                    ;
+                    // ]);
                 })->orWhere(function ($q) use ($user) {
                     $q->where('causer_type', get_class($user))
                         ->where('causer_id', $user->id);

--- a/app/Http/Controllers/Api/V1/AuditLogController.php
+++ b/app/Http/Controllers/Api/V1/AuditLogController.php
@@ -50,9 +50,9 @@ class AuditLogController extends Controller
         $userIdsInThisCustodian = [];
 
         if ($loggedInUser->custodian_user_id !== null) {
-            $custodianId = CustodianUser::where('id', $loggedInUser->custodian_user_id)->value('custodian_id');
-            $userIdsInThisCustodian = User::whereIn('custodian_user_id',
-                CustodianUser::where('custodian_id', $custodianId)->select('id')
+            $custodianId = $loggedInUser->custodian_user?->custodian_id;
+            $userIdsInThisCustodian = User::whereHas('custodian_user', fn($q) =>
+                $q->where('custodian_id', $custodianId)
             )->pluck('id')->toArray();
         }
 

--- a/app/Http/Controllers/Api/V1/AuditLogController.php
+++ b/app/Http/Controllers/Api/V1/AuditLogController.php
@@ -146,10 +146,10 @@ class AuditLogController extends Controller
                     }
 
                     if (
-                        isset($activityLog->properties['new']) &&
-                        isset($activityLog->properties['new']['email'])
+                        isset($activityLog->properties['attributes']) &&
+                        isset($activityLog->properties['attributes']['email'])
                     ) {
-                        $activityLog->properties['new']['email'] = 'hidden';
+                        $activityLog->properties['attributes']['email'] = 'hidden';
                     }
                 }
 

--- a/app/Http/Controllers/Api/V1/AuditLogController.php
+++ b/app/Http/Controllers/Api/V1/AuditLogController.php
@@ -76,7 +76,6 @@ class AuditLogController extends Controller
                     ]);
                 });
             })
-            ->whereJsonDoesntContainKey('properties->attributes->email')
             ->whereHasMorph('subject', self::ALLOWED_TYPES)
             ->where(function ($query) {
                 $query->whereNull('causer_type')
@@ -128,6 +127,16 @@ class AuditLogController extends Controller
                 ) {
                     $activityLog->description = '';
                 }
+
+                $old = $activityLog->properties['old'] ?? [];
+                if (isset($old['email'])) {
+                    $old['email'] = '***';
+                }
+                $attributes = $activityLog->properties['attributes'] ?? [];
+                if (isset($attributes['email'])) {
+                    $attributes['email'] = '***';
+                }
+                $activityLog->properties = ['old' => $old, 'attributes' => $attributes];
 
                 return $activityLog;
             });


### PR DESCRIPTION
Previously, custodians could see all activity logs of their users, including activity logs associated to other custodians.

This PR fixes that so custodians only see activity logs associated to their own actions or to the actions of the subject.

It also adds masking of email addresses to avoid their unnecessary exposure on the FE.

https://hdruk.atlassian.net/browse/REGISTRY-2826