### PR TITLE
fix(REGISTRY-2832): Fix replacements in email subject lines

### DIFF
--- a/app/Http/Controllers/Api/V1/EmailLogController.php
+++ b/app/Http/Controllers/Api/V1/EmailLogController.php
@@ -5,7 +5,7 @@ namespace App\Http\Controllers\Api\V1;
 use SendGridService;
 use Exception;
 use App\Models\EmailLog;
-use App\Jobs\SentHtmlEmalJob;
+use App\Jobs\SendHtmlEmailJob;
 use App\Http\Traits\Responses;
 use App\Http\Controllers\Controller;
 use Illuminate\Support\Facades\Gate;
@@ -108,7 +108,7 @@ class EmailLogController extends Controller
         }
 
         try {
-            SentHtmlEmalJob::dispatch($id);
+            SendHtmlEmailJob::dispatch($id);
 
             return $this->OKResponse('Resend email job dispatched for email log id ' . $id);
         } catch (Exception $e) {

--- a/app/Jobs/SendEmailJob.php
+++ b/app/Jobs/SendEmailJob.php
@@ -80,7 +80,7 @@ class SendEmailJob implements ShouldQueue
                 if (is_null($checkEmailLog)) {
                     EmailLog::create([
                         'to' => $this->to['email'],
-                        'subject' => $this->template['subject'],
+                        'subject' => strtr($this->template['subject'], $this->replacements),
                         'template' => $this->template['identifier'],
                         'body' => $html,
                         'job_uuid' => $jobUuid,
@@ -104,7 +104,7 @@ class SendEmailJob implements ShouldQueue
                 case 'sendgrid':
                     $sentMessage = new SendGridEmail();
                     $sentMessage->setToEmail($this->to['email'])
-                        ->setSubject($this->template['subject'])
+                        ->setSubject(strtr($this->template['subject'], $this->replacements))
                         ->setHtmlContent($html)
                         ->setJobUuid($jobUuid)
                         ->send();

--- a/app/Jobs/SendHtmlEmailJob.php
+++ b/app/Jobs/SendHtmlEmailJob.php
@@ -15,7 +15,7 @@ use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 
-class SentHtmlEmalJob implements ShouldQueue
+class SendHtmlEmailJob implements ShouldQueue
 {
     use Dispatchable;
     use InteractsWithQueue;
@@ -47,7 +47,7 @@ class SentHtmlEmalJob implements ShouldQueue
 
         DebugLog::create([
             'class' => __CLASS__,
-            'log' => 'SentHtmlEmalJob created with parameters: ' . json_encode([
+            'log' => 'SendHtmlEmailJob created with parameters: ' . json_encode([
                 'id' => $id,
             ]),
         ]);
@@ -65,7 +65,7 @@ class SentHtmlEmalJob implements ShouldQueue
         if (is_null($emailLog)) {
             DebugLog::create([
                 'class' => __CLASS__,
-                'log' => 'SentHtmlEmalJob No email log found for id ' . $this->id . '. The job will exit without sending email.',
+                'log' => 'SendHtmlEmailJob No email log found for id ' . $this->id . '. The job will exit without sending email.',
             ]);
 
             return;
@@ -89,7 +89,7 @@ class SentHtmlEmalJob implements ShouldQueue
 
         DebugLog::create([
             'class' => __CLASS__,
-            'log' => 'SentHtmlEmalJob prepare for sending email : ' . json_encode([
+            'log' => 'SendHtmlEmailJob prepare for sending email : ' . json_encode([
                 'id' => $this->id,
                 'subject' => $subject,
                 'to' => $to,
@@ -121,7 +121,7 @@ class SentHtmlEmalJob implements ShouldQueue
 
                     break;
                 default:
-                    throw new \Exception('Mail driver not supported in SentHtmlEmalJob: ' . config('mail.default'));
+                    throw new \Exception('Mail driver not supported in SendHtmlEmailJob: ' . config('mail.default'));
             }
 
             event(new EmailSentSuccessfully($jobUuid, $messageId));
@@ -146,7 +146,7 @@ class SentHtmlEmalJob implements ShouldQueue
             if ($isLastAttempt) {
                 DebugLog::create([
                     'class' => __CLASS__,
-                    'log' => 'SentHtmlEmalJob reached max attempts for job UUID ' . $jobUuid . '. No more retries will be made.',
+                    'log' => 'SendHtmlEmailJob reached max attempts for job UUID ' . $jobUuid . '. No more retries will be made.',
                 ]);
 
                 // delete the email log after final failed attempt
@@ -160,7 +160,7 @@ class SentHtmlEmalJob implements ShouldQueue
         EmailLog::where('id', $this->id)->delete();
         DebugLog::create([
             'class' => __CLASS__,
-            'log' => 'SentHtmlEmalJob email sent for id ' . $this->id . ' to ' . $to . ' with message ID ' . $messageId,
+            'log' => 'SendHtmlEmailJob email sent for id ' . $this->id . ' to ' . $to . ' with message ID ' . $messageId,
         ]);
     }
 

--- a/app/OrcID/OrcID.php
+++ b/app/OrcID/OrcID.php
@@ -5,7 +5,6 @@ namespace App\OrcID;
 use Http;
 use Exception;
 use App\Models\User;
-use App\Jobs\OrcIDScanner;
 use App\Models\UserApiToken;
 use Illuminate\Support\Facades\Log;
 


### PR DESCRIPTION
Email subject line was not having placeholders filled when using sendgrid. Additionally, the EmailLogs were being saved without the subject line being processed similarly.

This PR fixes these bugs, and additionally fixes the typoed filename `SentHtmlEmalJob` to `SendHtmlEmailJob`.