### PR TITLE
fix(REGISTRY-2776): Add associated CustodianProjectOrganisation information to CustodianProjectUser entries in CustodianHasProjectUserController::index()

### DIFF
--- a/app/Http/Controllers/Api/V1/CustodianHasProjectUserController.php
+++ b/app/Http/Controllers/Api/V1/CustodianHasProjectUserController.php
@@ -138,8 +138,8 @@ class CustodianHasProjectUserController extends Controller
                 ->select('custodian_has_project_has_user.*')
                 ->paginate($perPage);
 
-            $organisationIds = $records->map(fn ($r) => $r->projectHasUser?->affiliation?->organisation_id)->filter()->unique()->values();
-            $projectIds = $records->map(fn ($r) => $r->projectHasUser?->project_id)->filter()->unique()->values();
+            $organisationIds = $records->map(fn ($r) => $r->projectHasUser->affiliation?->organisation_id)->filter()->unique()->values();
+            $projectIds = $records->map(fn ($r) => $r->projectHasUser->project_id)->filter()->unique()->values();
 
             if ($organisationIds->isNotEmpty() && $projectIds->isNotEmpty()) {
                 $chpoMap = CustodianHasProjectOrganisation::query()
@@ -153,8 +153,8 @@ class CustodianHasProjectUserController extends Controller
                     ->keyBy(fn ($chpo) => $chpo->projectOrganisation->project_id . '_' . $chpo->projectOrganisation->organisation_id);
 
                 $records->each(function ($record) use ($chpoMap) {
-                    $projectId = $record->projectHasUser?->project_id;
-                    $organisationId = $record->projectHasUser?->affiliation?->organisation_id;
+                    $projectId = $record->projectHasUser->project_id;
+                    $organisationId = $record->projectHasUser->affiliation?->organisation_id;
                     $record->setRelation('custodianProjectOrganisation', $chpoMap->get("{$projectId}_{$organisationId}"));
                 });
             }

--- a/app/Http/Controllers/Api/V1/CustodianHasProjectUserController.php
+++ b/app/Http/Controllers/Api/V1/CustodianHasProjectUserController.php
@@ -14,6 +14,7 @@ use App\Http\Controllers\Controller;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Gate;
 use App\Models\CustodianHasProjectUser;
+use App\Models\CustodianHasProjectOrganisation;
 use App\Traits\Notifications\NotificationCustodianManager;
 use App\Http\Requests\CustodianHasProjectUser\GetCustodianHasProjectUser;
 use App\Http\Requests\CustodianHasProjectUser\GetAllCustodianHasProjectUser;
@@ -136,6 +137,27 @@ class CustodianHasProjectUserController extends Controller
                 ->applySorting()
                 ->select('custodian_has_project_has_user.*')
                 ->paginate($perPage);
+
+            $organisationIds = $records->map(fn ($r) => $r->projectHasUser?->affiliation?->organisation_id)->filter()->unique()->values();
+            $projectIds = $records->map(fn ($r) => $r->projectHasUser?->project_id)->filter()->unique()->values();
+
+            if ($organisationIds->isNotEmpty() && $projectIds->isNotEmpty()) {
+                $chpoMap = CustodianHasProjectOrganisation::query()
+                    ->where('custodian_id', $custodianId)
+                    ->whereHas('projectOrganisation', function ($q) use ($organisationIds, $projectIds) {
+                        $q->whereIn('organisation_id', $organisationIds)
+                          ->whereIn('project_id', $projectIds);
+                    })
+                    ->with(['modelState.state', 'projectOrganisation:id,project_id,organisation_id'])
+                    ->get()
+                    ->keyBy(fn ($chpo) => $chpo->projectOrganisation->project_id . '_' . $chpo->projectOrganisation->organisation_id);
+
+                $records->each(function ($record) use ($chpoMap) {
+                    $projectId = $record->projectHasUser?->project_id;
+                    $organisationId = $record->projectHasUser?->affiliation?->organisation_id;
+                    $record->setRelation('custodianProjectOrganisation', $chpoMap->get("{$projectId}_{$organisationId}"));
+                });
+            }
 
             return $this->OKResponse($records);
         } catch (Exception $e) {


### PR DESCRIPTION
> AI disclaimer - Claude was used for this. The necessary relationships were identified by me, before Claude suggested options for implementation and implemented this.

Adds associated CustodianProjectOrganisation information to CustodianProjectUser entries in CustodianHasProjectUserController::index(). This relationship is complex given the mixture of intermediate relationships, and so this implementation provides the simplest link.

See https://github.com/HDRUK/safepeopleregistry-web/pull/829 to see it in use