### PR TITLE
fix(REGISTRY-0000): Fix naming of facade to meet psr-4 autoloading standard

### DIFF
--- a/app/RulesEngineManagementController/RulesEngineManagementControllerFacade.php
+++ b/app/RulesEngineManagementController/RulesEngineManagementControllerFacade.php
@@ -4,7 +4,7 @@ namespace App\RulesEngineManagementController;
 
 use Illuminate\Support\Facades\Facade;
 
-class RulesEngineManagementController extends Facade
+class RulesEngineManagementControllerFacade extends Facade
 {
     protected static function getFacadeAccessor(): string
     {


### PR DESCRIPTION
Fixes a warning in CI:

> Class App\RulesEngineManagementController\RulesEngineManagementController located in ./app/RulesEngineManagementController/RulesEngineManagementControllerFacade.php does not comply with psr-4 autoloading standard (rule: App\ => ./app). Skipping.
