### PR TITLE
fix(REGISTRY-0000): fix CI failures

### DIFF
--- a/app/Jobs/OrcIDScanner.php
+++ b/app/Jobs/OrcIDScanner.php
@@ -2,7 +2,7 @@
 
 namespace App\Jobs;
 
-use OrcID;
+use App\OrcID\OrcIDFacade as OrcID;
 use Throwable;
 use Carbon\Carbon;
 use App\Models\User;


### PR DESCRIPTION
> Claude Sonnet 4.6 was used to identify the likely causes of this failure and propose solutions.

Use direct import rather than alias to avoid CI failures due to lazy loading of aliases. We'd been seeing intermittent (but very frequent) static analysis failures like this:
```
Error: Call to static method getPublicToken() on an unknown class OrcID.
Error: Call to static method getOrcIDRecord() on an unknown class OrcID.
Error: Call to static method getOrcIDRecord() on an unknown class OrcID.
Error: Call to static method getOrcIDRecord() on an unknown class OrcID.
 ------ ---------------------------------------------------------------------- 
  Line   Jobs/OrcIDScanner.php                                                 
 ------ ---------------------------------------------------------------------- 
  77     Call to static method getPublicToken() on an unknown class OrcID.     
         🪪  class.notFound                                                    
         💡  Learn more at https://phpstan.org/user-guide/discovering-symbols  
  138    Call to static method getOrcIDRecord() on an unknown class OrcID.     
         🪪  class.notFound                                                    
         💡  Learn more at https://phpstan.org/user-guide/discovering-symbols  
  168    Call to static method getOrcIDRecord() on an unknown class OrcID.     
         🪪  class.notFound                                                    
         💡  Learn more at https://phpstan.org/user-guide/discovering-symbols  
  207    Call to static method getOrcIDRecord() on an unknown class OrcID.     
         🪪  class.notFound                                                    
         💡  Learn more at https://phpstan.org/user-guide/discovering-symbols  
 ------ ---------------------------------------------------------------------- 
 ```