### PR TITLE
feat(REGISTRY-2619): Update Accreditations model to be used for Accredited Researcher Registrations

### DIFF
--- a/app/Http/Controllers/Api/V1/AccreditationController.php
+++ b/app/Http/Controllers/Api/V1/AccreditationController.php
@@ -113,13 +113,10 @@ class AccreditationController extends Controller
             $input = $request->all();
 
             $accreditation = Accreditation::create([
-                'awarded_at' => Carbon::parse($input['awarded_at'])->toDateString(),
-                'awarding_body_name' => $input['awarding_body_name'],
-                'awarding_body_ror' => isset($input['awarding_body_ror']) ?
-                    $input['awarding_body_ror'] : '',
-                'title' => $input['title'],
-                'expires_at' => Carbon::parse($input['expires_at'])->toDateString(),
-                'awarded_locale' => $input['awarded_locale'],
+                'associated_organisation_name' => $input['associated_organisation_name'],
+                'id_string' => $input['id_string'],
+                'issue_date' => Carbon::parse($input['issue_date'])->toDateString(),
+                'expiry_date' => Carbon::parse($input['expiry_date'])->toDateString(),
             ]);
 
             RegistryHasAccreditation::create([
@@ -183,12 +180,10 @@ class AccreditationController extends Controller
             $input = $request->all();
             $accreditation = Accreditation::where('id', $id)->first();
 
-            $accreditation->awarded_at = Carbon::parse($input['awarded_at'])->toDateString();
-            $accreditation->awarding_body_name = $input['awarding_body_name'];
-            $accreditation->awarding_body_ror = $input['awarding_body_ror'];
-            $accreditation->title = $input['title'];
-            $accreditation->expires_at = Carbon::parse($input['expires_at'])->toDateString();
-            $accreditation->awarded_locale = $input['awarded_locale'];
+            $accreditation->associated_organisation_name = $input['associated_organisation_name'];
+            $accreditation->id_string = $input['id_string'];
+            $accreditation->issue_date = Carbon::parse($input['issue_date'])->toDateString();
+            $accreditation->expiry_date = Carbon::parse($input['expiry_date'])->toDateString();
 
             $accreditation->save();
 

--- a/app/Jobs/OrcIDScanner.php
+++ b/app/Jobs/OrcIDScanner.php
@@ -185,19 +185,23 @@ class OrcIDScanner implements ShouldQueue
                 // is no real unique constraints on the table. We need to hard link this to
                 // registry_id instead. Future scope, as this is a larger change impacting several
                 // areas of the code.
-                $accreditation = Accreditation::create([
-                    'awarded_at' => $dates['startDate'],
-                    'awarding_body_name' => Arr::get($organisation, 'name', ''),
-                    'awarding_body_ror' => Arr::get($organisation, 'disambiguated-organization.disambiguated-organization-identifier', ''),
-                    'title' => $title,
-                    'expires_at' => $dates['endDate'],
-                    'awarded_locale' => Arr::get($organisation, 'address.country', ''),
-                ]);
 
-                RegistryHasAccreditation::firstOrCreate([
-                    'registry_id' => $this->user->registry_id,
-                    'accreditation_id' => $accreditation->id,
-                ]);
+                // TODO: SC - this is removed while we are repurposing the accreditations table,
+                // and we'd need to re-evaluate the contents of the payload to determine what
+                // we want to store in the accreditations table.
+                // $accreditation = Accreditation::create([
+                //     'awarded_at' => $dates['startDate'],
+                //     'awarding_body_name' => Arr::get($organisation, 'name', ''),
+                //     'awarding_body_ror' => Arr::get($organisation, 'disambiguated-organization.disambiguated-organization-identifier', ''),
+                //     'title' => $title,
+                //     'expires_at' => $dates['endDate'],
+                //     'awarded_locale' => Arr::get($organisation, 'address.country', ''),
+                // ]);
+
+                // RegistryHasAccreditation::firstOrCreate([
+                //     'registry_id' => $this->user->registry_id,
+                //     'accreditation_id' => $accreditation->id,
+                // ]);
             }
         }
     }

--- a/app/Models/Accreditation.php
+++ b/app/Models/Accreditation.php
@@ -18,42 +18,30 @@ use Illuminate\Database\Eloquent\Model;
  *         description="Unique identifier for the accreditation"
  *     ),
  *     @OA\Property(
- *         property="awarded_at",
+ *         property="associated_organisation_name",
  *         type="string",
- *         format="date-time",
- *         example="2025-06-25T12:00:00Z",
- *         description="Date when the accreditation was awarded"
+ *         example="University of Example",
+ *         description="Name of the associated organisation"
  *     ),
  *     @OA\Property(
- *         property="awarding_body_name",
+ *         property="id_string",
  *         type="string",
- *         example="Health Research Authority",
- *         description="Name of the awarding body"
+ *         example="123456",
+ *         description="ID string for the accreditation"
  *     ),
  *     @OA\Property(
- *         property="awarding_body_ror",
+ *         property="issue_date",
  *         type="string",
- *         example="https://ror.org/12345",
- *         description="ROR identifier for the awarding body"
+ *         format="date",
+ *         example="2023-01-01",
+ *         description="Date when the accreditation was issued"
  *     ),
  *     @OA\Property(
- *         property="title",
+ *         property="expiry_date",
  *         type="string",
- *         example="ISO 27001 Certification",
- *         description="Title of the accreditation"
- *     ),
- *     @OA\Property(
- *         property="expires_at",
- *         type="string",
- *         format="date-time",
- *         example="2026-06-25T12:00:00Z",
+ *         format="date",
+ *         example="2026-06-25",
  *         description="Date when the accreditation expires"
- *     ),
- *     @OA\Property(
- *         property="awarded_locale",
- *         type="string",
- *         example="UK",
- *         description="Locale where the accreditation was awarded"
  *     ),
  *     @OA\Property(
  *         property="created_at",
@@ -74,24 +62,20 @@ use Illuminate\Database\Eloquent\Model;
  * @property int $id
  * @property \Illuminate\Support\Carbon|null $created_at
  * @property \Illuminate\Support\Carbon|null $updated_at
- * @property string $awarded_at
- * @property string $awarding_body_name
- * @property string|null $awarding_body_ror
- * @property string $title
- * @property string $expires_at
- * @property string $awarded_locale
+ * @property string $associated_organisation_name
+ * @property string $id_string
+ * @property string $issue_date
+ * @property string $expiry_date
  * @method static \Database\Factories\AccreditationFactory factory($count = null, $state = [])
  * @method static \Illuminate\Database\Eloquent\Builder<static>|Accreditation newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder<static>|Accreditation newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder<static>|Accreditation query()
- * @method static \Illuminate\Database\Eloquent\Builder<static>|Accreditation whereAwardedAt($value)
- * @method static \Illuminate\Database\Eloquent\Builder<static>|Accreditation whereAwardedLocale($value)
- * @method static \Illuminate\Database\Eloquent\Builder<static>|Accreditation whereAwardingBodyName($value)
- * @method static \Illuminate\Database\Eloquent\Builder<static>|Accreditation whereAwardingBodyRor($value)
- * @method static \Illuminate\Database\Eloquent\Builder<static>|Accreditation whereCreatedAt($value)
- * @method static \Illuminate\Database\Eloquent\Builder<static>|Accreditation whereExpiresAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Accreditation whereAssociatedOrganisationName($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Accreditation whereIdString($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Accreditation whereIssueDate($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Accreditation whereExpiryDate($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|Accreditation whereId($value)
- * @method static \Illuminate\Database\Eloquent\Builder<static>|Accreditation whereTitle($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Accreditation whereCreatedAt($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|Accreditation whereUpdatedAt($value)
  * @mixin \Eloquent
  */
@@ -104,11 +88,9 @@ class Accreditation extends Model
     public $timestamps = true;
 
     protected $fillable = [
-        'awarded_at',
-        'awarding_body_name',
-        'awarding_body_ror',
-        'title',
-        'expires_at',
-        'awarded_locale',
+        'associated_organisation_name',
+        'id_string',
+        'issue_date',
+        'expiry_date',
     ];
 }

--- a/database/factories/AccreditationFactory.php
+++ b/database/factories/AccreditationFactory.php
@@ -20,12 +20,10 @@ class AccreditationFactory extends Factory
         $awardedDate = Carbon::parse(fake()->date());
 
         return [
-            'awarded_at' => $awardedDate->toDateString(),
-            'awarding_body_name' => fake()->company(),
-            'awarding_body_ror' => fake()->url(),
-            'title' => 'Safe Researcher Training',
-            'expires_at' => $awardedDate->addYear(2)->toDateString(),
-            'awarded_locale' => 'GB',
+            'associated_organisation_name' => fake()->company(),
+            'id_string' => fake()->uuid(),
+            'issue_date' => $awardedDate->toDateString(),
+            'expiry_date' => $awardedDate->addYear(2)->toDateString(),
         ];
     }
 }

--- a/database/migrations/2026_06_29_135819_repurpose_accreditations_table.php
+++ b/database/migrations/2026_06_29_135819_repurpose_accreditations_table.php
@@ -14,7 +14,7 @@ return new class extends Migration
         
         Schema::table('accreditations', function (Blueprint $table) {
             $table->string('associated_organisation_name')->nullable()->after('id');
-            $table->string('id_string')->nullable()->after('associated_organisation_name');
+            $table->string('id_string')->after('associated_organisation_name');
             $table->date('issue_date')->nullable()->after('id_string');
             $table->date('expiry_date')->nullable()->after('issue_date');
             $table->dropColumn('awarded_at');

--- a/database/migrations/2026_06_29_135819_repurpose_accreditations_table.php
+++ b/database/migrations/2026_06_29_135819_repurpose_accreditations_table.php
@@ -1,0 +1,47 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        
+        Schema::table('accreditations', function (Blueprint $table) {
+            $table->string('associated_organisation_name')->nullable()->after('id');
+            $table->string('id_string')->nullable()->after('associated_organisation_name');
+            $table->date('issue_date')->nullable()->after('id_string');
+            $table->date('expiry_date')->nullable()->after('issue_date');
+            $table->dropColumn('awarded_at');
+            $table->dropColumn('awarding_body_name');
+            $table->dropColumn('awarding_body_ror');
+            $table->dropColumn('title');
+            $table->dropColumn('expires_at');
+            $table->dropColumn('awarded_locale');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('accreditations', function (Blueprint $table) {
+            $table->dropColumn('associated_organisation_name');
+            $table->dropColumn('id_string');
+            $table->dropColumn('issue_date');
+            $table->dropColumn('expiry_date');
+            $table->string('awarded_at', 10)->default(''); // in form of MM/YYYY
+            $table->string('awarding_body_name', 255)->default('');
+            $table->string('awarding_body_ror', 255)->nullable()->default(null);
+            $table->text('title');
+            $table->string('expires_at', 10)->default(''); // in form of MM/YYYY
+            $table->string('awarded_locale', 255)->default(''); // country
+        });
+    }
+};

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -80,12 +80,10 @@ class UserSeeder extends Seeder
         $awardedDate = Carbon::parse(fake()->date());
 
         $accreditation = Accreditation::create([
-            'awarded_at' => $awardedDate->toDateString(),
-            'awarding_body_name' => fake()->company(),
-            'awarding_body_ror' => fake()->url(),
-            'title' => 'Safe Researcher Training',
-            'expires_at' => $awardedDate->addYear(2)->toDateString(),
-            'awarded_locale' => 'GB',
+            'associated_organisation_name' => fake()->company(),
+            'id_string' => fake()->uuid(),
+            'issue_date' => $awardedDate->toDateString(),
+            'expiry_date' => $awardedDate->addYear(2)->toDateString(),
         ]);
         RegistryHasAccreditation::create([
             'registry_id' => $registry->id,

--- a/tests/Feature/AccreditationTest.php
+++ b/tests/Feature/AccreditationTest.php
@@ -24,6 +24,11 @@ class AccreditationTest extends TestCase
         $this->withUsers();
 
         $this->registry = Registry::where('id', $this->user->registry_id)->first();
+
+        $this->company1 = fake()->company();
+        $this->id1 = fake()->uuid();
+        $this->company2 = fake()->company();
+        $this->id2 = fake()->uuid();
     }
 
     public function test_the_application_can_list_accreditations_by_registry_id(): void
@@ -48,7 +53,7 @@ class AccreditationTest extends TestCase
 
         $this->assertArrayHaskey('data', $response);
         $this->assertTrue(count($content['data']) === 1);
-        $this->assertEquals($content['data'][0]['title'], 'Safe Researcher Training');
+        $this->assertEquals($content['data'][0]['associated_organisation_name'], $this->company1);
     }
 
     public function test_the_application_cannot_list_accreditations_by_registry_id(): void
@@ -125,8 +130,8 @@ class AccreditationTest extends TestCase
 
         $response->assertStatus(200);
 
-        $this->assertEquals($content['data']['title'], 'Safe Researcher Training. The Sequel!!');
-        $this->assertEquals($content['data']['awarded_locale'], 'UK');
+        $this->assertEquals($content['data']['associated_organisation_name'], $this->company2);
+        $this->assertEquals($content['data']['id_string'], $this->id2);
     }
 
     public function test_the_application_cannot_update_accreditations_by_registry_id(): void
@@ -200,8 +205,8 @@ class AccreditationTest extends TestCase
         $awardedDate = Carbon::parse(fake()->date());
 
         return [
-            'associated_organisation_name' => fake()->company(),
-            'id_string' => fake()->uuid(),
+            'associated_organisation_name' => $this->company1,
+            'id_string' => $this->id1,
             'issue_date' => $awardedDate->toDateString(),
             'expiry_date' => $awardedDate->addYear(2)->toDateString(),
         ];
@@ -212,8 +217,8 @@ class AccreditationTest extends TestCase
         $awardedDate = Carbon::parse(fake()->date());
 
         return [
-            'associated_organisation_name' => fake()->company(),
-            'id_string' => fake()->uuid(),
+            'associated_organisation_name' => $this->company2,
+            'id_string' => $this->id2,
             'issue_date' => $awardedDate->toDateString(),
             'expiry_date' => $awardedDate->addYear(4)->toDateString(),
         ];
@@ -222,7 +227,7 @@ class AccreditationTest extends TestCase
     private function prepareEditedAccreditationPayload(): array
     {
         return [
-            'title' => 'Safe Researcher Training - The Sequel!',
+            'associated_organisation_name' => $this->company1,
         ];
     }
 }

--- a/tests/Feature/AccreditationTest.php
+++ b/tests/Feature/AccreditationTest.php
@@ -200,12 +200,10 @@ class AccreditationTest extends TestCase
         $awardedDate = Carbon::parse(fake()->date());
 
         return [
-            'awarded_at' => $awardedDate->toDateString(),
-            'awarding_body_name' => fake()->company(),
-            'awarding_body_ror' => fake()->url(),
-            'title' => 'Safe Researcher Training',
-            'expires_at' => $awardedDate->addYear(2)->toDateString(),
-            'awarded_locale' => 'GB',
+            'associated_organisation_name' => fake()->company(),
+            'id_string' => fake()->uuid(),
+            'issue_date' => $awardedDate->toDateString(),
+            'expiry_date' => $awardedDate->addYear(2)->toDateString(),
         ];
     }
 
@@ -214,12 +212,10 @@ class AccreditationTest extends TestCase
         $awardedDate = Carbon::parse(fake()->date());
 
         return [
-            'awarded_at' => $awardedDate->toDateString(),
-            'awarding_body_name' => fake()->company(),
-            'awarding_body_ror' => fake()->url(),
-            'title' => 'Safe Researcher Training. The Sequel!!',
-            'expires_at' => $awardedDate->addYear(4)->toDateString(),
-            'awarded_locale' => 'UK',
+            'associated_organisation_name' => fake()->company(),
+            'id_string' => fake()->uuid(),
+            'issue_date' => $awardedDate->toDateString(),
+            'expiry_date' => $awardedDate->addYear(4)->toDateString(),
         ];
     }
 


### PR DESCRIPTION
Since the Accreditations model is entirely unused so far on the FE, and contains no data on any environment, we re-purpose this slightly to hold the data we want for the Accredited Researcher registrations. It's unclear whether this was always the intended use-case or not!