### PR TITLE
feat(REGISTRY-2811): Seeders tidyup

### DIFF
--- a/database/migrations/2026_06_30_134440_remove_custodian_has_validation_check.php
+++ b/database/migrations/2026_06_30_134440_remove_custodian_has_validation_check.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        // Will cause data loss, but this table is no longer used and the data is not needed,
+        // having been superceded by validation_check->custodian_id
+        Schema::dropIfExists('custodian_has_validation_check');
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::create('custodian_has_validation_check', function (Blueprint $table) {
+            $table->foreignId('custodian_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('validation_check_id')->constrained()->cascadeOnDelete();
+            $table->primary(['custodian_id', 'validation_check_id']);
+        });
+    }
+};

--- a/database/seeders/BaseDemoSeeder.php
+++ b/database/seeders/BaseDemoSeeder.php
@@ -87,10 +87,11 @@ class BaseDemoSeeder extends Seeder
             'organisation_size' => 2,
             'website' => 'https://www.website1.com/',
             'system_approved' => true,
+            'system_approved_at' => Carbon::now(),
             'unclaimed' => 0
         ]);
 
-        $org1->setState(State::STATE_ORGANISATION_REGISTERED);
+        $org1->setState(State::STATE_PENDING);
 
         /*CustodianHasOrganisation::create([
             'organisation_id' => $org1->id,

--- a/database/seeders/ValidationCheckSeeder.php
+++ b/database/seeders/ValidationCheckSeeder.php
@@ -2,6 +2,7 @@
 
 namespace Database\Seeders;
 
+use App\Models\Custodian;
 use App\Models\Organisation;
 use App\Models\ProjectHasUser;
 use App\Models\ValidationCheck;
@@ -14,6 +15,8 @@ class ValidationCheckSeeder extends Seeder
      */
     public function run(): void
     {
+        $custodians = Custodian::all();
+
         foreach (ProjectHasUser::defaultValidationChecks() as $check) {
             ValidationCheck::updateOrCreate(
                 [
@@ -26,6 +29,20 @@ class ValidationCheckSeeder extends Seeder
                     'enabled' => 1
                 ]
             );
+
+            foreach ($custodians as $custodian) {
+                ValidationCheck::updateOrCreate(
+                    [
+                        'name' => $check['name'],
+                        'applies_to' => ProjectHasUser::class,
+                        'custodian_id' => $custodian->id,
+                    ],
+                    [
+                        'description' => $check['description'],
+                        'enabled' => 1
+                    ]
+                );
+            }
         }
 
         foreach (Organisation::defaultValidationChecks() as $check) {
@@ -40,6 +57,20 @@ class ValidationCheckSeeder extends Seeder
                     'enabled' => 1
                 ]
             );
+
+            foreach ($custodians as $custodian) {
+                ValidationCheck::updateOrCreate(
+                    [
+                        'name' => $check['name'],
+                        'applies_to' => Organisation::class,
+                        'custodian_id' => $custodian->id,
+                    ],
+                    [
+                        'description' => $check['description'],
+                        'enabled' => 1
+                    ]
+                );
+            }
         }
     }
 }

--- a/tests/Feature/ValidationLogTest.php
+++ b/tests/Feature/ValidationLogTest.php
@@ -650,9 +650,9 @@ class ValidationLogTest extends TestCase
         Organisation::truncate();
         Custodian::truncate();
         ValidationLog::truncate();
-        ValidationCheck::truncate();
+        // ValidationCheck::truncate();
 
-        var_dump("Before: " . ValidationLog::count() . " " . ValidationLog::where('entity_type', Custodian::class)->where('secondary_entity_type', Organisation::class)->count());
+        var_dump("Before: " . ValidationLog::count() . " " . ValidationCheck::count() . " " . ValidationLog::where('entity_type', Custodian::class)->where('secondary_entity_type', Organisation::class)->count());
 
         $defaultChecks = Organisation::defaultValidationChecks();
 
@@ -667,12 +667,12 @@ class ValidationLogTest extends TestCase
             $newValidationCheck->custodian_id = $newCustodian->id;
             $newValidationCheck->save();
         }
-        var_dump("Middle: " . ValidationLog::count() . " " . ValidationLog::where('entity_type', Custodian::class)->where('secondary_entity_type', Organisation::class)->count());
+        var_dump("Middle: " . ValidationLog::count() . " " . ValidationCheck::count() . " " . ValidationLog::where('entity_type', Custodian::class)->where('secondary_entity_type', Organisation::class)->count());
 
         Organisation::factory()->create();
 
         $expectedLogCount = count($defaultChecks) * Custodian::count() * Organisation::count();
-        var_dump("After: " . ValidationLog::count() . " " . ValidationLog::where('entity_type', Custodian::class)->where('secondary_entity_type', Organisation::class)->count());
+        var_dump("After: " . ValidationLog::count() . " " . ValidationCheck::count() . " " . ValidationLog::where('entity_type', Custodian::class)->where('secondary_entity_type', Organisation::class)->count());
         var_dump("Expected log count: $expectedLogCount Custodian count: " . Custodian::count() . " Organisation count: " . Organisation::count() . " Default checks count: " . count($defaultChecks));
         $this->assertEquals(
             $expectedLogCount,

--- a/tests/Feature/ValidationLogTest.php
+++ b/tests/Feature/ValidationLogTest.php
@@ -651,6 +651,8 @@ class ValidationLogTest extends TestCase
         Custodian::truncate();
         ValidationLog::truncate();
 
+        var_dump("Before: " . ValidationLog::count() . " " . ValidationLog::where('entity_type', Custodian::class)->where('secondary_entity_type', Organisation::class)->count());
+
         $defaultChecks = Organisation::defaultValidationChecks();
 
         // Create initial custodian + organisation
@@ -664,10 +666,12 @@ class ValidationLogTest extends TestCase
             $newValidationCheck->custodian_id = $newCustodian->id;
             $newValidationCheck->save();
         }
+        var_dump("Middle: " . ValidationLog::count() . " " . ValidationLog::where('entity_type', Custodian::class)->where('secondary_entity_type', Organisation::class)->count());
 
         Organisation::factory()->create();
 
         $expectedLogCount = count($defaultChecks) * Custodian::count() * Organisation::count();
+        var_dump("After: " . ValidationLog::count() . " " . ValidationLog::where('entity_type', Custodian::class)->where('secondary_entity_type', Organisation::class)->count());
         var_dump("Expected log count: $expectedLogCount Custodian count: " . Custodian::count() . " Organisation count: " . Organisation::count() . " Default checks count: " . count($defaultChecks));
         $this->assertEquals(
             $expectedLogCount,

--- a/tests/Feature/ValidationLogTest.php
+++ b/tests/Feature/ValidationLogTest.php
@@ -699,9 +699,7 @@ class ValidationLogTest extends TestCase
         $expectedLogCount = count($defaultChecks) * Custodian::count() * Organisation::count();
 
         $actualCount = ValidationLog::where('entity_type', Custodian::class)
-            ->where('entity_id', $newCustodian->id)
             ->where('secondary_entity_type', Organisation::class)
-            ->where('secondary_entity_id', Organisation::first()->id)
             ->count();
 
         $this->assertEquals(
@@ -717,9 +715,7 @@ class ValidationLogTest extends TestCase
         $this->assertEquals(
             $expectedLogCount,
             ValidationLog::where('entity_type', Custodian::class)
-                ->where('entity_id', $newCustodian->id)
                 ->where('secondary_entity_type', Organisation::class)
-                ->where('secondary_entity_id', $newOrganisation->id)
                 ->count()
         );
     }

--- a/tests/Feature/ValidationLogTest.php
+++ b/tests/Feature/ValidationLogTest.php
@@ -668,7 +668,7 @@ class ValidationLogTest extends TestCase
         Organisation::factory()->create();
 
         $expectedLogCount = count($defaultChecks) * Custodian::count() * Organisation::count();
-
+        var_dump("Expected log count: $expectedLogCount Custodian count: " . Custodian::count() . " Organisation count: " . Organisation::count() . " Default checks count: " . count($defaultChecks));
         $this->assertEquals(
             $expectedLogCount,
             ValidationLog::where('entity_type', Custodian::class)

--- a/tests/Feature/ValidationLogTest.php
+++ b/tests/Feature/ValidationLogTest.php
@@ -652,8 +652,6 @@ class ValidationLogTest extends TestCase
         ValidationLog::truncate();
         ValidationCheck::where('custodian_id', '!=', null)->delete();
 
-        var_dump("Before: " . ValidationLog::count() . " " . ValidationCheck::count() . " " . ValidationLog::where('entity_type', Custodian::class)->where('secondary_entity_type', Organisation::class)->count());
-
         $defaultChecks = Organisation::defaultValidationChecks();
 
         // Create initial custodian + organisation
@@ -667,13 +665,11 @@ class ValidationLogTest extends TestCase
             $newValidationCheck->custodian_id = $newCustodian->id;
             $newValidationCheck->save();
         }
-        var_dump("Middle: " . ValidationLog::count() . " " . ValidationCheck::count() . " " . ValidationLog::where('entity_type', Custodian::class)->where('secondary_entity_type', Organisation::class)->count());
 
         Organisation::factory()->create();
 
         $expectedLogCount = count($defaultChecks) * Custodian::count() * Organisation::count();
-        var_dump("After: " . ValidationLog::count() . " " . ValidationCheck::count() . " " . ValidationLog::where('entity_type', Custodian::class)->where('secondary_entity_type', Organisation::class)->count());
-        var_dump("Expected log count: $expectedLogCount Custodian count: " . Custodian::count() . " Organisation count: " . Organisation::count() . " Default checks count: " . count($defaultChecks));
+
         $this->assertEquals(
             $expectedLogCount,
             ValidationLog::where('entity_type', Custodian::class)

--- a/tests/Feature/ValidationLogTest.php
+++ b/tests/Feature/ValidationLogTest.php
@@ -650,7 +650,7 @@ class ValidationLogTest extends TestCase
         Organisation::truncate();
         Custodian::truncate();
         ValidationLog::truncate();
-        // ValidationCheck::truncate();
+        ValidationCheck::where('custodian_id', '!=', null)->delete();
 
         var_dump("Before: " . ValidationLog::count() . " " . ValidationCheck::count() . " " . ValidationLog::where('entity_type', Custodian::class)->where('secondary_entity_type', Organisation::class)->count());
 

--- a/tests/Feature/ValidationLogTest.php
+++ b/tests/Feature/ValidationLogTest.php
@@ -650,6 +650,7 @@ class ValidationLogTest extends TestCase
         Organisation::truncate();
         Custodian::truncate();
         ValidationLog::truncate();
+        ValidationCheck::truncate();
 
         var_dump("Before: " . ValidationLog::count() . " " . ValidationLog::where('entity_type', Custodian::class)->where('secondary_entity_type', Organisation::class)->count());
 

--- a/tests/Feature/ValidationLogTest.php
+++ b/tests/Feature/ValidationLogTest.php
@@ -677,7 +677,9 @@ class ValidationLogTest extends TestCase
         $this->assertEquals(
             $expectedLogCount,
             ValidationLog::where('entity_type', Custodian::class)
+                ->where('entity_id', $newCustodian->id)
                 ->where('secondary_entity_type', Organisation::class)
+                ->where('secondary_entity_id', Organisation::first()->id)
                 ->count()
         );
 
@@ -697,7 +699,9 @@ class ValidationLogTest extends TestCase
         $expectedLogCount = count($defaultChecks) * Custodian::count() * Organisation::count();
 
         $actualCount = ValidationLog::where('entity_type', Custodian::class)
+            ->where('entity_id', $newCustodian->id)
             ->where('secondary_entity_type', Organisation::class)
+            ->where('secondary_entity_id', Organisation::first()->id)
             ->count();
 
         $this->assertEquals(
@@ -713,7 +717,9 @@ class ValidationLogTest extends TestCase
         $this->assertEquals(
             $expectedLogCount,
             ValidationLog::where('entity_type', Custodian::class)
+                ->where('entity_id', $newCustodian->id)
                 ->where('secondary_entity_type', Organisation::class)
+                ->where('secondary_entity_id', $newOrganisation->id)
                 ->count()
         );
     }


### PR DESCRIPTION
https://hdruk.atlassian.net/browse/REGISTRY-2811

1. Remove `custodian_has_validation_check` table as this relationship was removed in https://github.com/HDRUK/safepeopleregistry-api/pull/740
2. Seed per-Custodian validation checks
3. Approve the first Organisation in the seeders