### PR TITLE
fix(REGISTRY-000): Fix custodian_user_id / custodian_id confusion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,14 +27,14 @@ jobs:
       - name: Composer install
         run: "composer install"
 
-      - name: Run code sniffer
-        run: "composer run lint"
+      # - name: Run code sniffer
+      #   run: "composer run lint"
 
       - name: Run swagger check
         run: php artisan l5-swagger:generate
 
-      - name: Run static analysis
-        run: "composer run phpstan"
+      # - name: Run static analysis
+      #   run: "composer run phpstan"
 
       - name: Run unit tests
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,14 +27,14 @@ jobs:
       - name: Composer install
         run: "composer install"
 
-      # - name: Run code sniffer
-      #   run: "composer run lint"
+      - name: Run code sniffer
+        run: "composer run lint"
 
       - name: Run swagger check
         run: php artisan l5-swagger:generate
 
-      # - name: Run static analysis
-      #   run: "composer run phpstan"
+      - name: Run static analysis
+        run: "composer run phpstan"
 
       - name: Run unit tests
         env:

--- a/app/Traits/Notifications/NotificationCustodianManager.php
+++ b/app/Traits/Notifications/NotificationCustodianManager.php
@@ -39,7 +39,7 @@ trait NotificationCustodianManager
             return;
         }
 
-        $custodianId = $loggedInUser->custodian_user?->custodian_id;
+        $custodianId = $loggedInUser->custodian_user->custodian_id;
 
         // users
         $userIds = CustodianHasProjectUser::query()
@@ -208,7 +208,7 @@ trait NotificationCustodianManager
 
         // user
         $userIds = CustodianHasProjectUser::query()
-            ->where('custodian_id', $loggedInUser?->custodian_user?->custodian_id)
+            ->where('custodian_id', $loggedInUser?->custodian_user->custodian_id)
             ->with([
                 'projectHasUser.registry.user:id,registry_id,first_name,last_name,email',
                 'projectHasUser.project',
@@ -227,7 +227,7 @@ trait NotificationCustodianManager
 
         // organisation
         $organisationIds = CustodianHasProjectOrganisation::query()
-            ->where('custodian_id', $loggedInUser?->custodian_user?->custodian_id)
+            ->where('custodian_id', $loggedInUser?->custodian_user->custodian_id)
             ->with([
                 'projectOrganisation',
             ])
@@ -246,7 +246,7 @@ trait NotificationCustodianManager
         // custodian
         $userCustodians = User::whereIn(
             'custodian_user_id',
-            CustodianUser::where('custodian_id', $loggedInUser?->custodian_user?->custodian_id)
+            CustodianUser::where('custodian_id', $loggedInUser?->custodian_user->custodian_id)
                 ->pluck('id')
         )->get();
 
@@ -267,7 +267,7 @@ trait NotificationCustodianManager
 
         $userCustodians = User::whereIn(
             'custodian_user_id',
-            CustodianUser::where('custodian_id', $loggedInUser?->custodian_user?->custodian_id)
+            CustodianUser::where('custodian_id', $loggedInUser?->custodian_user->custodian_id)
                 ->pluck('id')
         )->get();
 
@@ -288,7 +288,7 @@ trait NotificationCustodianManager
 
         $userCustodians = User::whereIn(
             'custodian_user_id',
-            CustodianUser::where('custodian_id', $loggedInUser?->custodian_user?->custodian_id)
+            CustodianUser::where('custodian_id', $loggedInUser?->custodian_user->custodian_id)
                 ->whereNot('id', $approver->id)
                 ->pluck('id')
         )->get();
@@ -372,7 +372,7 @@ trait NotificationCustodianManager
 
         $userCustodians = User::whereIn(
             'custodian_user_id',
-            CustodianUser::where('custodian_id', $loggedInUser?->custodian_user?->custodian_id)
+            CustodianUser::where('custodian_id', $loggedInUser?->custodian_user->custodian_id)
                 ->pluck('id')
         )->get();
 
@@ -393,7 +393,7 @@ trait NotificationCustodianManager
 
         $userCustodians = User::whereIn(
             'custodian_user_id',
-            CustodianUser::where('custodian_id', $loggedInUser?->custodian_user?->custodian_id)
+            CustodianUser::where('custodian_id', $loggedInUser?->custodian_user->custodian_id)
                 ->pluck('id')
         )->get();
 
@@ -414,7 +414,7 @@ trait NotificationCustodianManager
 
         $userCustodians = User::whereIn(
             'custodian_user_id',
-            CustodianUser::where('custodian_id', $loggedInUser?->custodian_user?->custodian_id)
+            CustodianUser::where('custodian_id', $loggedInUser?->custodian_user->custodian_id)
                 ->pluck('id')
         )->get();
 
@@ -462,7 +462,7 @@ trait NotificationCustodianManager
         // custodian
         $userCustodians = User::whereIn(
             'custodian_user_id',
-            CustodianUser::where('custodian_id', $loggedInUser?->custodian_user?->custodian_id)
+            CustodianUser::where('custodian_id', $loggedInUser?->custodian_user->custodian_id)
                 ->pluck('id')
         )->get();
         foreach ($userCustodians as $userCustodian) {

--- a/app/Traits/Notifications/NotificationCustodianManager.php
+++ b/app/Traits/Notifications/NotificationCustodianManager.php
@@ -462,7 +462,7 @@ trait NotificationCustodianManager
         // custodian
         $userCustodians = User::whereIn(
             'custodian_user_id',
-            CustodianUser::where('custodian_id', $loggedInUser?->custodian_user->custodian_id)
+            CustodianUser::where('custodian_id', $loggedInUser?->custodian_user_id)
                 ->pluck('id')
         )->get();
         foreach ($userCustodians as $userCustodian) {

--- a/app/Traits/Notifications/NotificationCustodianManager.php
+++ b/app/Traits/Notifications/NotificationCustodianManager.php
@@ -462,7 +462,7 @@ trait NotificationCustodianManager
         // custodian
         $userCustodians = User::whereIn(
             'custodian_user_id',
-            CustodianUser::where('custodian_id', $loggedInUser?->custodian_user_id)
+            CustodianUser::where('custodian_id', $loggedInUser?->custodian_user->custodian_id)
                 ->pluck('id')
         )->get();
         foreach ($userCustodians as $userCustodian) {

--- a/app/Traits/Notifications/NotificationCustodianManager.php
+++ b/app/Traits/Notifications/NotificationCustodianManager.php
@@ -35,11 +35,11 @@ trait NotificationCustodianManager
         $loggedInUser = User::where('id', $loggedInUserId)->first();
         $project = Project::where('id', $projectId)->first();
 
-        if (is_null($loggedInUser) || is_null($loggedInUser->custodian_user_id) || is_null($project)) {
+        if (is_null($loggedInUser) || is_null($loggedInUser->custodian_user?->custodian_id) || is_null($project)) {
             return;
         }
 
-        $custodianId = $loggedInUser->custodian_user_id;
+        $custodianId = $loggedInUser->custodian_user?->custodian_id;
 
         // users
         $userIds = CustodianHasProjectUser::query()
@@ -208,7 +208,7 @@ trait NotificationCustodianManager
 
         // user
         $userIds = CustodianHasProjectUser::query()
-            ->where('custodian_id', $loggedInUser?->custodian_user_id)
+            ->where('custodian_id', $loggedInUser?->custodian_user?->custodian_id)
             ->with([
                 'projectHasUser.registry.user:id,registry_id,first_name,last_name,email',
                 'projectHasUser.project',
@@ -227,7 +227,7 @@ trait NotificationCustodianManager
 
         // organisation
         $organisationIds = CustodianHasProjectOrganisation::query()
-            ->where('custodian_id', $loggedInUser?->custodian_user_id)
+            ->where('custodian_id', $loggedInUser?->custodian_user?->custodian_id)
             ->with([
                 'projectOrganisation',
             ])
@@ -246,7 +246,7 @@ trait NotificationCustodianManager
         // custodian
         $userCustodians = User::whereIn(
             'custodian_user_id',
-            CustodianUser::where('custodian_id', $loggedInUser?->custodian_user_id)
+            CustodianUser::where('custodian_id', $loggedInUser?->custodian_user?->custodian_id)
                 ->pluck('id')
         )->get();
 
@@ -267,7 +267,7 @@ trait NotificationCustodianManager
 
         $userCustodians = User::whereIn(
             'custodian_user_id',
-            CustodianUser::where('custodian_id', $loggedInUser?->custodian_user_id)
+            CustodianUser::where('custodian_id', $loggedInUser?->custodian_user?->custodian_id)
                 ->pluck('id')
         )->get();
 
@@ -288,7 +288,7 @@ trait NotificationCustodianManager
 
         $userCustodians = User::whereIn(
             'custodian_user_id',
-            CustodianUser::where('custodian_id', $loggedInUser?->custodian_user_id)
+            CustodianUser::where('custodian_id', $loggedInUser?->custodian_user?->custodian_id)
                 ->whereNot('id', $approver->id)
                 ->pluck('id')
         )->get();
@@ -372,7 +372,7 @@ trait NotificationCustodianManager
 
         $userCustodians = User::whereIn(
             'custodian_user_id',
-            CustodianUser::where('custodian_id', $loggedInUser?->custodian_user_id)
+            CustodianUser::where('custodian_id', $loggedInUser?->custodian_user?->custodian_id)
                 ->pluck('id')
         )->get();
 
@@ -393,7 +393,7 @@ trait NotificationCustodianManager
 
         $userCustodians = User::whereIn(
             'custodian_user_id',
-            CustodianUser::where('custodian_id', $loggedInUser?->custodian_user_id)
+            CustodianUser::where('custodian_id', $loggedInUser?->custodian_user?->custodian_id)
                 ->pluck('id')
         )->get();
 
@@ -414,7 +414,7 @@ trait NotificationCustodianManager
 
         $userCustodians = User::whereIn(
             'custodian_user_id',
-            CustodianUser::where('custodian_id', $loggedInUser?->custodian_user_id)
+            CustodianUser::where('custodian_id', $loggedInUser?->custodian_user?->custodian_id)
                 ->pluck('id')
         )->get();
 
@@ -462,7 +462,7 @@ trait NotificationCustodianManager
         // custodian
         $userCustodians = User::whereIn(
             'custodian_user_id',
-            CustodianUser::where('custodian_id', $loggedInUser?->custodian_user_id)
+            CustodianUser::where('custodian_id', $loggedInUser?->custodian_user?->custodian_id)
                 ->pluck('id')
         )->get();
         foreach ($userCustodians as $userCustodian) {

--- a/database/seeders/CustodianSeeder.php
+++ b/database/seeders/CustodianSeeder.php
@@ -50,7 +50,7 @@ class CustodianSeeder extends Seeder
                 ]);
             }
 
-            for ($x = 0; $x < 1; $x++) {
+            for ($x = 0; $x < 2; $x++) {
                 $iu = CustodianUser::factory()->create([
                     'first_name' => 'Custodian',
                     'last_name' => 'Admin',

--- a/tests/Feature/CustodianProjectTest.php
+++ b/tests/Feature/CustodianProjectTest.php
@@ -111,6 +111,11 @@ class CustodianProjectTest extends TestCase
 
         $projectHasSponsor = ProjectHasSponsorship::where('project_id', $projectId)->first();
         $this->assertEquals((int)$projectHasSponsor->sponsor_id, (int)$organisation->id);
+        // Add assertion to check whether notification was sent to the custodian admin
+        $this->assertDatabaseHas('notifications', [
+            'notifiable_id' => $this->custodian_admin->id,
+            'type' => 'App\Notifications\CustodianAddSponsorToProject',
+        ]);
     }
 
 }

--- a/tests/Feature/CustodianProjectTest.php
+++ b/tests/Feature/CustodianProjectTest.php
@@ -26,7 +26,7 @@ class CustodianProjectTest extends TestCase
 
     public function setUp(): void
     {
-        $this->shouldFakeQueue();
+        $this->shouldFakeQueue = false;
         parent::setUp();
         $this->withUsers();
         $this->custodian = Custodian::where('id', $this->custodian_admin->custodian_user->custodian_id)

--- a/tests/Feature/CustodianProjectTest.php
+++ b/tests/Feature/CustodianProjectTest.php
@@ -26,6 +26,7 @@ class CustodianProjectTest extends TestCase
 
     public function setUp(): void
     {
+        $this->shouldFakeQueue();
         parent::setUp();
         $this->withUsers();
         $this->custodian = Custodian::where('id', $this->custodian_admin->custodian_user->custodian_id)

--- a/tests/Feature/CustodianTest.php
+++ b/tests/Feature/CustodianTest.php
@@ -143,7 +143,7 @@ class CustodianTest extends TestCase
 
         Queue::assertNothingPushed();
 
-        $response = $this->actingAs($this->admin)
+        $response = $this->actingAs($this->custodian_admin)
             ->json(
                 'POST',
                 self::TEST_URL . '/' . 2 . '/invite/',

--- a/tests/Feature/CustodianTest.php
+++ b/tests/Feature/CustodianTest.php
@@ -146,7 +146,7 @@ class CustodianTest extends TestCase
         $response = $this->actingAs($this->custodian_admin)
             ->json(
                 'POST',
-                self::TEST_URL . '/' . 2 . '/invite/',
+                self::TEST_URL . '/' . 1 . '/invite/',
             );
 
         $response->assertStatus(403);

--- a/tests/Feature/CustodianTest.php
+++ b/tests/Feature/CustodianTest.php
@@ -143,7 +143,7 @@ class CustodianTest extends TestCase
 
         Queue::assertNothingPushed();
 
-        $response = $this->actingAs($this->custodian_admin)
+        $response = $this->actingAs($this->admin)
             ->json(
                 'POST',
                 self::TEST_URL . '/' . 2 . '/invite/',
@@ -299,7 +299,7 @@ class CustodianTest extends TestCase
         $response = $this->actingAs($this->custodian_admin)
             ->json(
                 'PUT',
-                self::TEST_URL . '/1',
+                self::TEST_URL . '/2',
                 [
                     'name' => 'Updated Custodian',
                     'enabled' => false,
@@ -320,7 +320,7 @@ class CustodianTest extends TestCase
         $response = $this->actingAs($this->custodian_admin)
             ->json(
                 'PUT',
-                self::TEST_URL . '/2',
+                self::TEST_URL . '/1',
                 [
                     'name' => 'Updated Custodian',
                     'enabled' => false,
@@ -335,7 +335,7 @@ class CustodianTest extends TestCase
         $response = $this->actingAs($this->custodian_admin)
             ->json(
                 'DELETE',
-                self::TEST_URL . '/1'
+                self::TEST_URL . '/2'
             );
 
         $response->assertStatus(200);
@@ -346,7 +346,7 @@ class CustodianTest extends TestCase
         $response = $this->actingAs($this->custodian_admin)
             ->json(
                 'DELETE',
-                self::TEST_URL . '/2'
+                self::TEST_URL . '/1'
             );
 
         $response->assertStatus(403);

--- a/tests/Feature/PermissionMatrixTest.php
+++ b/tests/Feature/PermissionMatrixTest.php
@@ -41,7 +41,7 @@ class PermissionMatrixTest extends TestCase
         $this->user2->update(
             ['registry_id' => Registry::where('id', '!=', $this->user->registry_id)->inRandomOrder()->first()->id]
         );
-        $this->custodian2 = User::factory()->create(['user_group' => User::GROUP_CUSTODIANS]);
+        $this->first_custodian = User::factory()->create(['user_group' => User::GROUP_CUSTODIANS]);
         $cu = CustodianUser::create([
             'first_name' => fake()->firstname(),
             'last_name' => fake()->lastname(),
@@ -50,7 +50,7 @@ class PermissionMatrixTest extends TestCase
             'keycloak_id' => '',
             'custodian_id' => 1,
         ]);
-        $this->custodian2->update([
+        $this->first_custodian->update([
             'custodian_user_id' => $cu->id
         ]);
 
@@ -62,7 +62,7 @@ class PermissionMatrixTest extends TestCase
 
         $this->users = [
             'admin' => $this->admin,
-            'custodian1' => $this->custodian2,
+            'custodian1' => $this->first_custodian,
             'custodian2' => $this->custodian_admin,
             'organisation1' => $this->organisation_admin,
             'organisation2' => $this->organisation2,
@@ -380,8 +380,8 @@ class PermissionMatrixTest extends TestCase
                 ],
                 'permissions' => [
                     'admin' => 200,
-                    'custodian1' => 200,
-                    'custodian2' => 403,
+                    'custodian1' => 403,
+                    'custodian2' => 200,
                     'organisation1' => 403,
                     'organisation2' => 403,
                     'delegate' => 403,
@@ -391,14 +391,14 @@ class PermissionMatrixTest extends TestCase
             ],
             [
                 'method' => 'put',
-                'route' => '/users/' . $this->custodian2->id,
+                'route' => '/users/' . $this->first_custodian->id,
                 'payload' => [
                     'first_name'  => fake()->firstname()
                 ],
                 'permissions' => [
                     'admin' => 200,
-                    'custodian1' => 403,
-                    'custodian2' => 200,
+                    'custodian1' => 200,
+                    'custodian2' => 403,
                     'organisation1' => 403,
                     'organisation2' => 403,
                     'delegate' => 403,

--- a/tests/Feature/PermissionMatrixTest.php
+++ b/tests/Feature/PermissionMatrixTest.php
@@ -48,7 +48,7 @@ class PermissionMatrixTest extends TestCase
             'email' => fake()->email(),
             'provider' => '',
             'keycloak_id' => '',
-            'custodian_id' => 2,
+            'custodian_id' => 1,
         ]);
         $this->custodian2->update([
             'custodian_user_id' => $cu->id
@@ -62,8 +62,8 @@ class PermissionMatrixTest extends TestCase
 
         $this->users = [
             'admin' => $this->admin,
-            'custodian1' => $this->custodian_admin,
-            'custodian2' => $this->custodian2,
+            'custodian1' => $this->custodian2,
+            'custodian2' => $this->custodian_admin,
             'organisation1' => $this->organisation_admin,
             'organisation2' => $this->organisation2,
             'delegate' => $this->organisation_delegate,

--- a/tests/Feature/ProjectTest.php
+++ b/tests/Feature/ProjectTest.php
@@ -739,7 +739,7 @@ class ProjectTest extends TestCase
         $response = $this->actingAs($this->custodian_admin)
             ->json(
                 'GET',
-                self::TEST_URL . "/2/all_users"
+                self::TEST_URL . "/1/all_users"
             );
         $response->assertStatus(200);
     }
@@ -749,11 +749,11 @@ class ProjectTest extends TestCase
         $response = $this->actingAs($this->custodian_admin)
             ->json(
                 'GET',
-                self::TEST_URL . "/2/all_users?user_project_filter=in"
+                self::TEST_URL . "/1/all_users?user_project_filter=in"
             );
         $response->assertStatus(200);
         $responseData = count($response->decodeResponseJson()['data']['data']);
-        $projectHasUsers = ProjectHasUser::where('project_id', 2)->count();
+        $projectHasUsers = ProjectHasUser::where('project_id', 1)->count();
 
         $this->assertEquals($responseData, $projectHasUsers);
     }
@@ -763,7 +763,7 @@ class ProjectTest extends TestCase
         $responseUsersInProjectBefore = $this->actingAs($this->custodian_admin)
             ->json(
                 'GET',
-                self::TEST_URL . "/2/all_users?user_project_filter=in"
+                self::TEST_URL . "/1/all_users?user_project_filter=in"
             );
 
         $responseUsersInProjectBefore->assertStatus(200);
@@ -772,7 +772,7 @@ class ProjectTest extends TestCase
         $responseAllUsers = $this->actingAs($this->custodian_admin)
             ->json(
                 'GET',
-                self::TEST_URL . "/2/all_users"
+                self::TEST_URL . "/1/all_users"
             );
 
         $responseAllUsers->assertStatus(200);
@@ -783,7 +783,7 @@ class ProjectTest extends TestCase
         $responseAddNewUserInProject =  $this->actingAs($this->custodian_admin)
             ->json(
                 'PUT',
-                self::TEST_URL . '/2/all_users',
+                self::TEST_URL . '/1/all_users',
                 [
                     'users' => $payload,
                 ]

--- a/tests/Feature/ProjectTest.php
+++ b/tests/Feature/ProjectTest.php
@@ -739,7 +739,7 @@ class ProjectTest extends TestCase
         $response = $this->actingAs($this->custodian_admin)
             ->json(
                 'GET',
-                self::TEST_URL . "/1/all_users"
+                self::TEST_URL . "/2/all_users"
             );
         $response->assertStatus(200);
     }
@@ -749,21 +749,21 @@ class ProjectTest extends TestCase
         $response = $this->actingAs($this->custodian_admin)
             ->json(
                 'GET',
-                self::TEST_URL . "/1/all_users?user_project_filter=in"
+                self::TEST_URL . "/2/all_users?user_project_filter=in"
             );
         $response->assertStatus(200);
         $responseData = count($response->decodeResponseJson()['data']['data']);
-        $projectHasUsers = ProjectHasUser::where('project_id', 1)->count();
+        $projectHasUsers = ProjectHasUser::where('project_id', 2)->count();
 
         $this->assertEquals($responseData, $projectHasUsers);
     }
 
-    public function test_the_application_can_asssign_claimed_users_to_project(): void
+    public function test_the_application_can_assign_claimed_users_to_project(): void
     {
         $responseUsersInProjectBefore = $this->actingAs($this->custodian_admin)
             ->json(
                 'GET',
-                self::TEST_URL . "/1/all_users?user_project_filter=in"
+                self::TEST_URL . "/2/all_users?user_project_filter=in"
             );
 
         $responseUsersInProjectBefore->assertStatus(200);
@@ -772,7 +772,7 @@ class ProjectTest extends TestCase
         $responseAllUsers = $this->actingAs($this->custodian_admin)
             ->json(
                 'GET',
-                self::TEST_URL . "/1/all_users"
+                self::TEST_URL . "/2/all_users"
             );
 
         $responseAllUsers->assertStatus(200);
@@ -783,7 +783,7 @@ class ProjectTest extends TestCase
         $responseAddNewUserInProject =  $this->actingAs($this->custodian_admin)
             ->json(
                 'PUT',
-                self::TEST_URL . '/1/all_users',
+                self::TEST_URL . '/2/all_users',
                 [
                     'users' => $payload,
                 ]

--- a/tests/Feature/ProjectTest.php
+++ b/tests/Feature/ProjectTest.php
@@ -41,7 +41,7 @@ class ProjectTest extends TestCase
     private function createProjectUserRelation()
     {
         $custodianUser = CustodianUser::first();
-        $custodian_admin = User::where('custodian_user_id', $custodianUser->id)->first();
+        $custodian_admin = User::where('custodian_user_id', $custodianUser->id)->orderBy('id', 'desc')->first();
         $custodian = Custodian::with('custodianUsers')->where('id', $custodianUser['custodian_id'])->first();
 
         ProjectHasUser::truncate();

--- a/tests/Feature/ProjectTest.php
+++ b/tests/Feature/ProjectTest.php
@@ -769,7 +769,7 @@ class ProjectTest extends TestCase
         $responseUsersInProjectBefore->assertStatus(200);
         $responseDataUsersInProjectBefore = $responseUsersInProjectBefore->decodeResponseJson()['data']['data'];
 
-        $responseAllUsers = $this->actingAs($this->custodian_admin)
+        $responseAllUsers = $this->actingAs(User::where('user_group', User::GROUP_CUSTODIANS)->first())
             ->json(
                 'GET',
                 self::TEST_URL . "/2/all_users"

--- a/tests/Feature/ProjectTest.php
+++ b/tests/Feature/ProjectTest.php
@@ -736,7 +736,7 @@ class ProjectTest extends TestCase
 
     public function test_the_application_can_get_project_users(): void
     {
-        $response = $this->actingAs(Custodian::first()->id)
+        $response = $this->actingAs(Custodian::first())
             ->json(
                 'GET',
                 self::TEST_URL . "/2/all_users"
@@ -746,7 +746,7 @@ class ProjectTest extends TestCase
 
     public function test_the_application_can_get_project_users_filter_in(): void
     {
-        $response = $this->actingAs(Custodian::first()->id)
+        $response = $this->actingAs(Custodian::first())
             ->json(
                 'GET',
                 self::TEST_URL . "/2/all_users?user_project_filter=in"
@@ -760,7 +760,7 @@ class ProjectTest extends TestCase
 
     public function test_the_application_can_assign_claimed_users_to_project(): void
     {
-        $responseUsersInProjectBefore = $this->actingAs(Custodian::first()->id)
+        $responseUsersInProjectBefore = $this->actingAs(Custodian::first())
             ->json(
                 'GET',
                 self::TEST_URL . "/2/all_users?user_project_filter=in"

--- a/tests/Feature/ProjectTest.php
+++ b/tests/Feature/ProjectTest.php
@@ -736,7 +736,7 @@ class ProjectTest extends TestCase
 
     public function test_the_application_can_get_project_users(): void
     {
-        $response = $this->actingAs(Custodian::first())
+        $response = $this->actingAs(User::where('user_group', User::GROUP_CUSTODIANS)->first())
             ->json(
                 'GET',
                 self::TEST_URL . "/2/all_users"
@@ -746,7 +746,7 @@ class ProjectTest extends TestCase
 
     public function test_the_application_can_get_project_users_filter_in(): void
     {
-        $response = $this->actingAs(Custodian::first())
+        $response = $this->actingAs(User::where('user_group', User::GROUP_CUSTODIANS)->first())
             ->json(
                 'GET',
                 self::TEST_URL . "/2/all_users?user_project_filter=in"
@@ -760,7 +760,7 @@ class ProjectTest extends TestCase
 
     public function test_the_application_can_assign_claimed_users_to_project(): void
     {
-        $responseUsersInProjectBefore = $this->actingAs(Custodian::first())
+        $responseUsersInProjectBefore = $this->actingAs(User::where('user_group', User::GROUP_CUSTODIANS)->first())
             ->json(
                 'GET',
                 self::TEST_URL . "/2/all_users?user_project_filter=in"

--- a/tests/Feature/ProjectTest.php
+++ b/tests/Feature/ProjectTest.php
@@ -736,34 +736,34 @@ class ProjectTest extends TestCase
 
     public function test_the_application_can_get_project_users(): void
     {
-        $response = $this->actingAs($this->custodian_admin)
+        $response = $this->actingAs(Custodian::first()->id)
             ->json(
                 'GET',
-                self::TEST_URL . "/1/all_users"
+                self::TEST_URL . "/2/all_users"
             );
         $response->assertStatus(200);
     }
 
     public function test_the_application_can_get_project_users_filter_in(): void
     {
-        $response = $this->actingAs($this->custodian_admin)
+        $response = $this->actingAs(Custodian::first()->id)
             ->json(
                 'GET',
-                self::TEST_URL . "/1/all_users?user_project_filter=in"
+                self::TEST_URL . "/2/all_users?user_project_filter=in"
             );
         $response->assertStatus(200);
         $responseData = count($response->decodeResponseJson()['data']['data']);
-        $projectHasUsers = ProjectHasUser::where('project_id', 1)->count();
+        $projectHasUsers = ProjectHasUser::where('project_id', 2)->count();
 
         $this->assertEquals($responseData, $projectHasUsers);
     }
 
     public function test_the_application_can_assign_claimed_users_to_project(): void
     {
-        $responseUsersInProjectBefore = $this->actingAs($this->custodian_admin)
+        $responseUsersInProjectBefore = $this->actingAs(Custodian::first()->id)
             ->json(
                 'GET',
-                self::TEST_URL . "/1/all_users?user_project_filter=in"
+                self::TEST_URL . "/2/all_users?user_project_filter=in"
             );
 
         $responseUsersInProjectBefore->assertStatus(200);
@@ -772,7 +772,7 @@ class ProjectTest extends TestCase
         $responseAllUsers = $this->actingAs($this->custodian_admin)
             ->json(
                 'GET',
-                self::TEST_URL . "/1/all_users"
+                self::TEST_URL . "/2/all_users"
             );
 
         $responseAllUsers->assertStatus(200);
@@ -783,7 +783,7 @@ class ProjectTest extends TestCase
         $responseAddNewUserInProject =  $this->actingAs($this->custodian_admin)
             ->json(
                 'PUT',
-                self::TEST_URL . '/1/all_users',
+                self::TEST_URL . '/2/all_users',
                 [
                     'users' => $payload,
                 ]

--- a/tests/Feature/ProjectTest.php
+++ b/tests/Feature/ProjectTest.php
@@ -780,7 +780,7 @@ class ProjectTest extends TestCase
 
         $payload = $this->createPayloadForAddNewUserToProject($responseDataUsersInProjectBefore, $responseDataAllUsers);
 
-        $responseAddNewUserInProject =  $this->actingAs($this->custodian_admin)
+        $responseAddNewUserInProject =  $this->actingAs(User::where('user_group', User::GROUP_CUSTODIANS)->first())
             ->json(
                 'PUT',
                 self::TEST_URL . '/2/all_users',

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -49,7 +49,7 @@ abstract class TestCase extends BaseTestCase
     {
         $this->user = User::where('user_group', User::GROUP_USERS)->first();
 
-        $this->custodian_admin = User::where('user_group', User::GROUP_CUSTODIANS)->first();
+        $this->custodian_admin = User::where('user_group', User::GROUP_CUSTODIANS)->orderBy('id', 'desc')->first();
 
         if (! $this->custodian_admin) {
             $this->custodian_admin = User::factory()->create([


### PR DESCRIPTION
Fix a heap of functions that all confuse custodian_user_id with custodian_id.

Previously, these functions incorrectly called `CustodianUser::where('custodian_id', $user->custodian_user_id)` when they should have been using `CustodianUser::where('custodian_id', $user->custodian_user->custodian_id)`.

The fact these weren't being picked up by testing highlighted a weakness in the tests - all the CustodianUsers in testing have the same ID as their associated Custodian.

This is fixed by adding 2 CustodianUsers per Custodian (rather than 1), and then making the standard `custodian_admin` used in testing the last (ID 4, Custodian 2) rather than the first (ID 1, Custodian 1).

This highlighted a couple of other tests that relied upon this ordering too, so they're fixed too.