### PR TITLE
fix(REGISTRY-1006): Organisations - add parent organisation (subsidiaries)

### DIFF
--- a/app/Http/Requests/Subsidiaries/UpdateSubsidiary.php
+++ b/app/Http/Requests/Subsidiaries/UpdateSubsidiary.php
@@ -28,7 +28,6 @@ class UpdateSubsidiary extends BaseFormRequest
                 'required',
                 'string',
                 'max:255',
-                'unique:subsidiaries,name',
             ],
         ];
     }


### PR DESCRIPTION
This check was preventing users from updating selected fields in the form. In order to successfully update the selected subsidiary, the user was required to also update the subsidiary name. Removing this check ensures that users can update any field without having to also update the name. 

FE Ticket: https://hdruk.atlassian.net/browse/REGISTRY-1006
Previous BE Ticket: https://hdruk.atlassian.net/browse/REGISTRY-1127