### PR TITLE
feat(REGISTRY-2899): Prevent changing affiliation email

### DIFF
--- a/app/Http/Controllers/Api/V1/AffiliationController.php
+++ b/app/Http/Controllers/Api/V1/AffiliationController.php
@@ -469,6 +469,13 @@ class AffiliationController extends Controller
                 $affiliation->verification_confirmed_at = null;
             }
 
+            // SC: We don't want to allow email updates through this endpoint right now, as it could lead to verification issues.
+            // We only allow email updates in the specific case where the user is changing an affiliation from historic to current,
+            // _and_ they haven't already set an email before. This cuts out the complex case while still allowing that one case
+            // (where we'd not have fired off a verification email yet).
+            if (!($input['current_employer'] && !$originalAffiliation['current_employer'] && empty($originalAffiliation['email']))) {
+                unset($input['email']);
+            }
             $affiliation->fill($input);
             $affiliation->save();
             $affiliation->refresh();

--- a/app/Http/Controllers/Api/V1/AffiliationController.php
+++ b/app/Http/Controllers/Api/V1/AffiliationController.php
@@ -307,16 +307,16 @@ class AffiliationController extends Controller
                 return $this->ErrorResponse('Organisation with id ' . $array['organisation_id'] . ' not found');
             }
 
-            $verificationCode = null;
+            $affiliation = Affiliation::create($array);
+
             if ($currentEmployer) {
                 $verificationCode = Str::uuid()->toString();
-                $array['verification_code'] = $verificationCode;
-                $array['verification_sent_at'] = Carbon::now();
-                $array['verification_confirmed_at'] = null;
-                $array['is_verified'] = 0;
+                $affiliation->verification_code = $verificationCode;
+                $affiliation->verification_sent_at = Carbon::now();
+                $affiliation->verification_confirmed_at = null;
+                $affiliation->is_verified = 0;
+                $affiliation->save();
             }
-
-            $affiliation = Affiliation::create($array);
 
             if ($currentEmployer && $verificationCode && !$isCurrentEmail) {
                 $affiliation->setState(State::STATE_AFFILIATION_EMAIL_VERIFY);
@@ -371,13 +371,10 @@ class AffiliationController extends Controller
                 return $this->ErrorResponse('Organisation with id ' .  $affiliation->organisation_id . ' not found');
             }
 
-            $array = [
-                'is_verified' => 0,
-                'verification_code' => Str::uuid()->toString(),
-                'verification_sent_at' => Carbon::now(),
-            ];
-
-            Affiliation::where('id', $id)->update($array);
+            $affiliation->is_verified = 0;
+            $affiliation->verification_code = Str::uuid()->toString();
+            $affiliation->verification_sent_at = Carbon::now();
+            $affiliation->save();
 
             $affiliation->setState(State::STATE_AFFILIATION_EMAIL_VERIFY);
 
@@ -467,10 +464,9 @@ class AffiliationController extends Controller
             $unclaimed = $affiliation->organisation->unclaimed;
 
             if (!$affiliation->is_verified && $input['current_employer']) {
-                $input['verification_code'] = Str::uuid()->toString();
-                $input['verification_sent_at'] = Carbon::now();
-                $input['verification_confirmed_at'] = null;
-                $input['is_verified'] = 0;
+                $affiliation->verification_code = Str::uuid()->toString();
+                $affiliation->verification_sent_at = Carbon::now();
+                $affiliation->verification_confirmed_at = null;
             }
 
             $affiliation->fill($input);
@@ -625,12 +621,11 @@ class AffiliationController extends Controller
             if (!is_null($custodianHasProjectUser)) {
                 $custodianHasProjectUser->setState(State::STATE_PENDING);
             }
-            $array = [
-                'verification_code' => null,
-                'is_verified' => 1,
-                'verification_confirmed_at' => Carbon::now(),
-            ];
-            $affiliation->update($array);
+            $affiliation->verification_code = null;
+            $affiliation->is_verified = 1;
+            $affiliation->verification_confirmed_at = Carbon::now();
+            $affiliation->save();
+
             return $this->OKResponse($affiliation);
         } catch (Exception $e) {
             throw new Exception($e->getMessage());

--- a/app/Http/Controllers/Api/V1/AffiliationController.php
+++ b/app/Http/Controllers/Api/V1/AffiliationController.php
@@ -469,8 +469,8 @@ class AffiliationController extends Controller
             if (!$affiliation->is_verified && $input['current_employer']) {
                 $input['verification_code'] = Str::uuid()->toString();
                 $input['verification_sent_at'] = Carbon::now();
-                $array['verification_confirmed_at'] = null;
-                $array['is_verified'] = 0;
+                $input['verification_confirmed_at'] = null;
+                $input['is_verified'] = 0;
             }
 
             $affiliation->fill($input);

--- a/app/Jobs/OrcIDScanner.php
+++ b/app/Jobs/OrcIDScanner.php
@@ -253,11 +253,13 @@ class OrcIDScanner implements ShouldQueue
                         'registry_id' => $this->user->registry_id,
                         'organisation_id' => $knownOrg->id ?? -1,
                         'member_id' => '',
-                        'verification_code' => null,
-                        'verification_sent_at' => null,
-                        'is_verified' => 0,
                         'orcid_organisation' => Arr::get($organisation, 'organization.name', ''),
                     ]);
+
+                    $affiliation->verification_code = null;
+                    $affiliation->verification_sent_at = null;
+                    $affiliation->is_verified = 0;
+                    $affiliation->save();
 
                     $affiliation->setState(State::STATE_AFFILIATION_INFO_REQUIRED);
                 }
@@ -283,11 +285,13 @@ class OrcIDScanner implements ShouldQueue
                         'registry_id' => $this->user->registry_id,
                         'organisation_id' => $knownOrg->id ?? -1,
                         'member_id' => '',
-                        'verification_code' => $verificationCode,
-                        'verification_sent_at' => $verificationSent,
-                        'is_verified' => 0,
                         'orcid_organisation' => $organisation->organisation_name,
                     ]);
+
+                    $affiliation->verification_code = $verificationCode;
+                    $affiliation->verification_sent_at = $verificationSent;
+                    $affiliation->is_verified = 0;
+                    $affiliation->save();
 
                     if ($organisation->unclaimed) {
                         $affiliation->setState(State::STATE_AFFILIATION_INFO_REQUIRED);

--- a/app/Models/Affiliation.php
+++ b/app/Models/Affiliation.php
@@ -208,12 +208,15 @@ class Affiliation extends Model
         'verdict_user_id',
         'verdict_date_actioned',
         'verdict_outcome',
+        'current_employer',
+        'orcid_organisation',
+    ];
+
+    protected $guarded = [
         'verification_code',
         'verification_sent_at',
         'verification_confirmed_at',
         'is_verified',
-        'current_employer',
-        'orcid_organisation',
     ];
 
     protected $casts = [


### PR DESCRIPTION
https://hdruk.atlassian.net/browse/REGISTRY-2899

This PR disables the ability for a user to change their Affiliation email except in specific circumstances (where the Affiliation is newly changing to "Current" and they've not previously set an email) since then the consequent actions in the app are safe.

I've also taken the opportunity to guard Affiliations' `verification_code`, `verification_sent_at`, `verification_confirmed_at`, and `is_verified` fields to avoid the possibility of users modifying these through mass-assignment.