### PR TITLE
fix(REGISTRY-2882): Don't unapprove an Organisation when it uploads a file

### DIFF
--- a/app/Http/Controllers/Api/V1/FileUploadController.php
+++ b/app/Http/Controllers/Api/V1/FileUploadController.php
@@ -323,10 +323,6 @@ class FileUploadController extends Controller
                     'file_id' => $fileIn->id,
                 ]);
 
-                Organisation::where('id', $organisation->id)->update([
-                    'system_approved' => 0,
-                ]);
-
                 $userAdmins = User::where('user_group', User::GROUP_ADMINS)->select(['id'])->get();
                 foreach ($userAdmins as $userAdmin) {
 


### PR DESCRIPTION
There will be a specific later flow for when an organisation uploads a new SRO document, which is the only case where unapproval might be warranted.